### PR TITLE
address space memory assetions

### DIFF
--- a/src/address_map/memory.rs
+++ b/src/address_map/memory.rs
@@ -33,7 +33,8 @@ pub struct Memory<T> {
 }
 
 impl<T> Memory<T> {
-    /// Allocates a new addressable memory module
+    /// Allocates a new addressable memory module taking both a start and stop
+    /// address.
     pub fn new(start_address: u16, stop_address: u16) -> Self {
         Memory {
             mem_type: PhantomData,
@@ -43,7 +44,7 @@ impl<T> Memory<T> {
         }
     }
 
-    /// Dump memory to a Vector
+    /// Dump converts the current state of memroy into a correspnding Vec<u8>.
     pub fn dump(&self) -> Vec<u8> {
         self.buffer.iter().copied().collect()
     }
@@ -61,12 +62,14 @@ impl<T> Memory<T> {
 }
 
 impl Addressable<u16> for Memory<ReadWrite> {
-    /// Reads a single byte at the specified address
+    /// Reads a single byte at the specified address returning the u8
+    /// representation of the value.
     fn read(&self, addr: u16) -> u8 {
         self.buffer[usize::from(addr)]
     }
 
-    /// Write assigns a single value to an address in memory
+    /// Assigns a single value to an address in memory returning a result if the
+    /// write was in range.
     fn write(&mut self, addr: u16, value: u8) -> Result<u8, String> {
         self.buffer[usize::from(addr)] = value;
         Ok(value)

--- a/src/address_map/memory.rs
+++ b/src/address_map/memory.rs
@@ -60,7 +60,7 @@ impl<T> Memory<T> {
     }
 }
 
-impl<T> Addressable<u16> for Memory<T> {
+impl Addressable<u16> for Memory<ReadWrite> {
     /// Reads a single byte at the specified address
     fn read(&self, addr: u16) -> u8 {
         self.buffer[usize::from(addr)]
@@ -70,5 +70,18 @@ impl<T> Addressable<u16> for Memory<T> {
     fn write(&mut self, addr: u16, value: u8) -> Result<u8, String> {
         self.buffer[usize::from(addr)] = value;
         Ok(value)
+    }
+}
+
+impl Addressable<u16> for Memory<ReadOnly> {
+    /// Reads a single byte at the specified address
+    fn read(&self, addr: u16) -> u8 {
+        self.buffer[usize::from(addr)]
+    }
+
+    /// write returns an error signifying that the memory is
+    /// read-only.
+    fn write(&mut self, _: u16, _: u8) -> Result<u8, String> {
+        Err("memory is read-only.".to_string())
     }
 }

--- a/src/address_map/memory.rs
+++ b/src/address_map/memory.rs
@@ -82,6 +82,6 @@ impl Addressable<u16> for Memory<ReadOnly> {
     /// write returns an error signifying that the memory is
     /// read-only.
     fn write(&mut self, _: u16, _: u8) -> Result<u8, String> {
-        Err("memory is read-only.".to_string())
+        Err("memory is read-only".to_string())
     }
 }

--- a/src/address_map/mod.rs
+++ b/src/address_map/mod.rs
@@ -19,7 +19,10 @@ where
     fn write(&mut self, offset: O, data: u8) -> Result<u8, WriteError>;
 }
 
-/// AddressMap
+/// AddressMap contains a mapping of address spaces to corresponding addressable
+/// IO with the purpose of acting as an address map. This time is, additionally,
+/// an implementation Addressable allowing all other components to interact with
+/// it as if it were a bus.
 #[derive(Default)]
 pub struct AddressMap<O: Into<usize>> {
     inner: HashMap<Range<O>, Box<dyn Addressable<O>>>,
@@ -35,7 +38,8 @@ where
         }
     }
 
-    /// register attempts to match a new range
+    /// register attempts takes a range, representing a range of addresses and
+    /// an addressable type for receiving read/write requests.
     pub fn register(
         mut self,
         range: Range<O>,

--- a/src/address_map/tests/memory.rs
+++ b/src/address_map/tests/memory.rs
@@ -20,6 +20,15 @@ fn should_persist_values_in_memory_when_written() {
 }
 
 #[test]
+fn should_throw_error_when_write_is_attempted_on_readonly_memory() {
+    let mut mem: Memory<ReadOnly> = Memory::new(0, std::u16::MAX);
+    assert_eq!(
+        Err("memory is read-only".to_string()),
+        mem.write(0x8000, 0xff)
+    );
+}
+
+#[test]
 fn should_dump_entire_state_of_memory() {
     let mut expected: Vec<u8> = Vec::new();
     expected.resize(std::u16::MAX as usize, 0);

--- a/src/address_map/tests/mod.rs
+++ b/src/address_map/tests/mod.rs
@@ -1,29 +1,42 @@
-use crate::address_map::Addressable;
+use crate::address_map::{
+    memory::{Memory, ReadOnly},
+    Addressable,
+};
 
 mod memory;
 
-macro_rules! u16_addresss_map {
+macro_rules! u16_address_map {
     () => {
-        $crate::address_map::AddressMap::<u16>::new()
-            .register(
-                0..std::u16::MAX,
-                Box::new($crate::address_map::memory::Memory::<
-                    $crate::address_map::memory::ReadOnly,
-                >::new(0, std::u16::MAX)),
-            )
-            .unwrap()
+        $crate::address_map::AddressMap::<u16>::new().register(
+            0..std::u16::MAX,
+            Box::new($crate::address_map::memory::Memory::<
+                $crate::address_map::memory::ReadOnly,
+            >::new(0, std::u16::MAX)),
+        )
+    };
+    ($am:expr) => {
+        $crate::address_map::AddressMap::<u16>::new().register(0..std::u16::MAX, Box::new($am))
+    };
+    ($range:expr, $am:expr) => {
+        $crate::address_map::AddressMap::<u16>::new().register($range, Box::new($am))
     };
 }
 
 #[test]
+fn should_register_valid_memory() {
+    let am = u16_address_map!(0..std::u16::MAX, Memory::<ReadOnly>::new(0, std::u16::MAX));
+    assert!(am.is_ok());
+}
+
+#[test]
 fn should_read_valid_memory() {
-    let am = u16_addresss_map!();
+    let am = u16_address_map!().unwrap();
     assert_eq!(0x00, am.read(0xffff));
 }
 
 #[test]
 fn should_write_valid_memory() {
-    let mut am = u16_addresss_map!();
+    let mut am = u16_address_map!().unwrap();
     assert!(am.write(0xaaaa, 0xff).is_ok());
     assert_eq!(0xff, am.read(0xaaaa));
 }

--- a/src/address_map/tests/mod.rs
+++ b/src/address_map/tests/mod.rs
@@ -10,7 +10,7 @@ macro_rules! u16_address_map {
         $crate::address_map::AddressMap::<u16>::new().register(
             0..std::u16::MAX,
             Box::new($crate::address_map::memory::Memory::<
-                $crate::address_map::memory::ReadOnly,
+                $crate::address_map::memory::ReadWrite,
             >::new(0, std::u16::MAX)),
         )
     };

--- a/src/address_map/tests/mod.rs
+++ b/src/address_map/tests/mod.rs
@@ -29,6 +29,14 @@ fn should_register_valid_memory() {
 }
 
 #[test]
+fn should_fail_when_registering_overlapping_address_space() {
+    let am = u16_address_map!(0..0x8000, Memory::<ReadOnly>::new(0, 0x8000)).unwrap();
+    assert!(am
+        .register(0..0x8000, Box::new(Memory::<ReadOnly>::new(0, 0x8000)))
+        .is_err());
+}
+
+#[test]
 fn should_read_valid_memory() {
     let am = u16_address_map!().unwrap();
     assert_eq!(0x00, am.read(0xffff));


### PR DESCRIPTION
# Introduction
Adds additional tests around

address space
  - to assert correct behaviour when registering new memory
  - macros for address space creations

memory
  - Read-only memory now fails to write memory with an error
  - added assertions around write behaviour for both RO and RW memory

# Linked Issues
resolves #4 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
