### PR TITLE
Move memory to vectors

### DIFF
--- a/src/address_map/tests/memory.rs
+++ b/src/address_map/tests/memory.rs
@@ -2,7 +2,6 @@ use crate::address_map::{
     memory::{Memory, ReadOnly, ReadWrite},
     Addressable,
 };
-use std::convert::TryFrom;
 
 #[test]
 fn should_initialize_memory_to_zeroes() {
@@ -46,7 +45,7 @@ fn should_load_memory_of_correct_size() {
     let mut expected: Vec<u8> = Vec::new();
     expected.resize(std::u16::MAX as usize, 0);
     expected[0x8000 as usize] = 0xff;
-    let rom = <[u8; std::u16::MAX as usize]>::try_from(expected.clone()).unwrap();
+    let rom = expected.clone();
 
     let mem: Memory<ReadWrite> = Memory::new(0, std::u16::MAX).load(rom);
 

--- a/src/address_map/tests/memory.rs
+++ b/src/address_map/tests/memory.rs
@@ -52,3 +52,15 @@ fn should_load_memory_of_correct_size() {
     let matches = expected == mem.dump();
     assert!(matches)
 }
+
+#[test]
+fn should_correctly_calculate_offsets() {
+    let mut mem: Memory<ReadWrite> = Memory::new(0x8000, std::u16::MAX);
+    mem.write(0x8000, 0xff).unwrap();
+
+    let data = mem.dump();
+    let first_value = data[0];
+
+    assert_eq!(0xff, first_value);
+    assert_eq!(0x8000 - 1, data.len());
+}


### PR DESCRIPTION
# Introduction
This PR switches the Memory type to use a vector instead of a pre-allocated array.

# Linked Issues
resolves #12 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
