### PR TITLE
Processor operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.1" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.1" }
+parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,3 @@ edition = "2018"
 
 [dependencies]
 scrap = { git = "https://github.com/ncatelli/scrap", tag = "v0.1.1" }
-parcel = { git = "https://github.com/ncatelli/parcel", tag = "v1.9.0" }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1,6 +1,18 @@
 #[cfg(test)]
 mod tests;
 
+pub trait Cyclable {
+    fn cycles(&self) -> usize {
+        1
+    }
+}
+
+pub trait Offset {
+    fn offset(&self) -> usize {
+        1
+    }
+}
+
 pub trait CPU<T> {
     fn step(cpu: T) -> T;
 }

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -1,8 +1,3 @@
-use crate::address_map::{
-    memory::{Memory, ReadWrite},
-    AddressMap, Addressable,
-};
-
 #[cfg(test)]
 mod tests;
 
@@ -10,70 +5,5 @@ pub trait CPU<T> {
     fn step(cpu: T) -> T;
 }
 
-mod register;
-use register::{GeneralPurpose, ProcessorStatus, ProgramCounter, Register, StackPointer};
-
-/// MOS6502 represents the 6502 CPU
-#[derive(Debug)]
-pub struct MOS6502 {
-    address_map: AddressMap<u16>,
-    pub acc: GeneralPurpose,
-    pub x: GeneralPurpose,
-    pub y: GeneralPurpose,
-    pub sp: StackPointer,
-    pub pc: ProgramCounter,
-    pub ps: ProcessorStatus,
-}
-
-impl MOS6502 {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// instantiates a new MOS6502 with a provided address_map.
-    pub fn with_addressmap(am: AddressMap<u16>) -> Self {
-        let mut cpu = Self::default();
-        cpu.address_map = am;
-        cpu
-    }
-
-    /// emulates the reset process of the CPU.
-    pub fn reset(self) -> Self {
-        let mut cpu = MOS6502::with_addressmap(self.address_map);
-        let lsb: u8 = cpu.address_map.read(0x7ffc);
-        let msb: u8 = cpu.address_map.read(0x7ffd);
-
-        cpu.pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
-        cpu
-    }
-}
-
-impl Default for MOS6502 {
-    fn default() -> Self {
-        Self {
-            address_map: AddressMap::new()
-                .register(
-                    0x0000..0x00FF,
-                    Box::new(Memory::<ReadWrite>::new(0x0000, 0x00FF)),
-                )
-                .unwrap()
-                .register(
-                    0x0100..0x01FF,
-                    Box::new(Memory::<ReadWrite>::new(0x0100, 0x01FF)),
-                )
-                .unwrap(),
-            acc: GeneralPurpose::default(),
-            x: GeneralPurpose::default(),
-            y: GeneralPurpose::default(),
-            sp: StackPointer::default(),
-            pc: ProgramCounter::default(),
-            ps: ProcessorStatus::default(),
-        }
-    }
-}
-
-impl<MOS6502> CPU<MOS6502> for MOS6502 {
-    fn step(cpu: MOS6502) -> MOS6502 {
-        cpu
-    }
-}
+pub mod mos6502;
+pub mod register;

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -14,7 +14,7 @@ pub trait Offset {
 }
 
 pub trait CPU<T> {
-    fn step(cpu: StepState<T>) -> StepState<T>;
+    fn step(self) -> StepState<T>;
 }
 
 /// Stores state between cycles.

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -14,7 +14,44 @@ pub trait Offset {
 }
 
 pub trait CPU<T> {
-    fn step(cpu: T) -> T;
+    fn step(cpu: StepState<T>) -> StepState<T>;
+}
+
+/// Stores state between cycles.
+pub struct StepState<T> {
+    remaining: usize, // Remaining cycles in operation
+    cpu: T,
+}
+
+impl<T> StepState<T> {
+    pub fn new(cycle: usize, cpu: T) -> Self {
+        Self {
+            remaining: cycle - 1,
+            cpu,
+        }
+    }
+
+    pub fn decrement(self) -> Self {
+        let remaining = self.remaining - 1;
+        Self {
+            remaining,
+            cpu: self.cpu,
+        }
+    }
+
+    pub fn ready(&self) -> bool {
+        self.remaining == 0
+    }
+
+    pub fn unwrap(self) -> T {
+        self.cpu
+    }
+}
+
+impl<T> From<StepState<T>> for (usize, T) {
+    fn from(stepstate: StepState<T>) -> Self {
+        (stepstate.remaining, stepstate.cpu)
+    }
 }
 
 pub mod mos6502;

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -9,6 +9,8 @@ use crate::{
     },
 };
 
+pub mod operations;
+
 /// MOS6502 represents the 6502 CPU
 #[derive(Debug)]
 pub struct MOS6502 {
@@ -72,102 +74,4 @@ impl<MOS6502> CPU<MOS6502> for MOS6502 {
     fn step(cpu: MOS6502) -> MOS6502 {
         cpu
     }
-}
-
-#[derive(Clone, Copy, PartialEq, Debug)]
-pub enum Mnemonic {
-    // Load-Store
-    LDA,
-    LDX,
-    LDY,
-    STA,
-    STX,
-    STY,
-
-    // Arithmetic
-    ADC,
-    SBC,
-    INC,
-    INX,
-    INY,
-    DEC,
-    DEX,
-    DEY,
-
-    // Shift and Rotate
-    ASL,
-    LSR,
-    ROL,
-    ROR,
-    AND,
-    ORA,
-    EOR,
-
-    // Compare and Test Bit
-    CMP,
-    CPX,
-    CPY,
-    BIT,
-
-    // Branch
-    BCC,
-    BCS,
-    BNE,
-    BEQ,
-    BPL,
-    BMI,
-    BVC,
-    BVS,
-
-    // Transfer
-    TAX,
-    TXA,
-    TAY,
-    TYA,
-    TSX,
-    TXS,
-
-    // Stack
-    PHA,
-    PLA,
-    PHP,
-    PLP,
-
-    // Subroutines and Jump
-    JMP,
-    JSR,
-    RTS,
-    RTI,
-
-    // Set and Clear
-    CLC,
-    SEC,
-    CLD,
-    SED,
-    CLI,
-    SEI,
-    CLV,
-
-    // Misc
-    BRK,
-    NOP,
-}
-
-/// AddressMode captures the Address mode type with a corresponding
-/// operand of the appropriate bit length.
-#[derive(Clone, Copy, PartialEq, Debug)]
-pub enum AddressMode {
-    Accumulator,
-    Implied,
-    Immediate(u8),
-    Absolute(u16),
-    ZeroPage(u8),
-    Relative(i8),
-    Indirect(u16),
-    AbsoluteIndexedWithX(u16),
-    AbsoluteIndexedWithY(u16),
-    ZeroPageIndexedWithX(u8),
-    ZeroPageIndexedWithY(u8),
-    IndexedIndirect(u8),
-    IndirectIndexed(u8),
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     cpu::{
         register::{GeneralPurpose, ProcessorStatus, ProgramCounter, Register, StackPointer},
-        CPU,
+        StepState, CPU,
     },
 };
 
@@ -70,8 +70,8 @@ impl Default for MOS6502 {
     }
 }
 
-impl<MOS6502> CPU<MOS6502> for MOS6502 {
-    fn step(cpu: MOS6502) -> MOS6502 {
-        cpu
+impl CPU<MOS6502> for MOS6502 {
+    fn step(cpu: StepState<MOS6502>) -> StepState<MOS6502> {
+        StepState::new(0, cpu.unwrap())
     }
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -1,3 +1,6 @@
+extern crate parcel;
+use parcel::Parser;
+
 use crate::{
     address_map::{
         memory::{Memory, ReadWrite},
@@ -5,11 +8,19 @@ use crate::{
     },
     cpu::{
         register::{GeneralPurpose, ProcessorStatus, ProgramCounter, Register, StackPointer},
-        StepState, CPU,
+        Cyclable, Offset, StepState, CPU,
     },
 };
 
+#[cfg(test)]
+mod tests;
+
 pub mod operations;
+use operations::{address_mode, mnemonic, Operation};
+
+trait Execute<T> {
+    fn execute(self, operation: T) -> Self;
+}
 
 /// MOS6502 represents the 6502 CPU
 #[derive(Debug)]
@@ -36,13 +47,13 @@ impl MOS6502 {
     }
 
     /// emulates the reset process of the CPU.
-    pub fn reset(self) -> Self {
+    pub fn reset(self) -> StepState<Self> {
         let mut cpu = MOS6502::with_addressmap(self.address_map);
         let lsb: u8 = cpu.address_map.read(0x7ffc);
         let msb: u8 = cpu.address_map.read(0x7ffd);
 
         cpu.pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
-        cpu
+        StepState::new(6, cpu)
     }
 }
 
@@ -71,7 +82,45 @@ impl Default for MOS6502 {
 }
 
 impl CPU<MOS6502> for MOS6502 {
-    fn step(cpu: StepState<MOS6502>) -> StepState<MOS6502> {
-        StepState::new(0, cpu.unwrap())
+    fn step(self) -> StepState<MOS6502> {
+        StepState::new(1, self).step()
+    }
+}
+
+impl CPU<MOS6502> for StepState<MOS6502> {
+    fn step(self) -> StepState<MOS6502> {
+        if !self.ready() {
+            self.decrement()
+        } else {
+            let mos = self.unwrap();
+            let pc = mos.pc.read();
+            let opcodes: [u8; 3] = [
+                mos.address_map.read(pc),
+                mos.address_map.read(pc + 1),
+                mos.address_map.read(pc + 2),
+            ];
+
+            // Parse correct operation
+            let oper = match opcodes[0] {
+                0xEA => Operation::new(mnemonic::NOP, address_mode::Implied).parse(&opcodes),
+                _ => Err(format!("unimplemented opcode: {}", opcodes[0])),
+            }
+            .unwrap()
+            .unwrap();
+
+            // run the operation to transform the cpu state
+            let mut mos = mos.execute(oper);
+
+            // set pc offsets and cycles as defined by operation.
+            let offset = oper.offset() as u16;
+            mos.pc = mos.pc.write(pc + offset);
+            StepState::new(oper.cycles(), mos)
+        }
+    }
+}
+
+impl Execute<Operation<mnemonic::NOP, address_mode::Implied>> for MOS6502 {
+    fn execute(self, _: Operation<mnemonic::NOP, address_mode::Implied>) -> Self {
+        self
     }
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -1,0 +1,173 @@
+use crate::{
+    address_map::{
+        memory::{Memory, ReadWrite},
+        AddressMap, Addressable,
+    },
+    cpu::{
+        register::{GeneralPurpose, ProcessorStatus, ProgramCounter, Register, StackPointer},
+        CPU,
+    },
+};
+
+/// MOS6502 represents the 6502 CPU
+#[derive(Debug)]
+pub struct MOS6502 {
+    address_map: AddressMap<u16>,
+    pub acc: GeneralPurpose,
+    pub x: GeneralPurpose,
+    pub y: GeneralPurpose,
+    pub sp: StackPointer,
+    pub pc: ProgramCounter,
+    pub ps: ProcessorStatus,
+}
+
+impl MOS6502 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// instantiates a new MOS6502 with a provided address_map.
+    pub fn with_addressmap(am: AddressMap<u16>) -> Self {
+        let mut cpu = Self::default();
+        cpu.address_map = am;
+        cpu
+    }
+
+    /// emulates the reset process of the CPU.
+    pub fn reset(self) -> Self {
+        let mut cpu = MOS6502::with_addressmap(self.address_map);
+        let lsb: u8 = cpu.address_map.read(0x7ffc);
+        let msb: u8 = cpu.address_map.read(0x7ffd);
+
+        cpu.pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
+        cpu
+    }
+}
+
+impl Default for MOS6502 {
+    fn default() -> Self {
+        Self {
+            address_map: AddressMap::new()
+                .register(
+                    0x0000..0x00FF,
+                    Box::new(Memory::<ReadWrite>::new(0x0000, 0x00FF)),
+                )
+                .unwrap()
+                .register(
+                    0x0100..0x01FF,
+                    Box::new(Memory::<ReadWrite>::new(0x0100, 0x01FF)),
+                )
+                .unwrap(),
+            acc: GeneralPurpose::default(),
+            x: GeneralPurpose::default(),
+            y: GeneralPurpose::default(),
+            sp: StackPointer::default(),
+            pc: ProgramCounter::default(),
+            ps: ProcessorStatus::default(),
+        }
+    }
+}
+
+impl<MOS6502> CPU<MOS6502> for MOS6502 {
+    fn step(cpu: MOS6502) -> MOS6502 {
+        cpu
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Mnemonic {
+    // Load-Store
+    LDA,
+    LDX,
+    LDY,
+    STA,
+    STX,
+    STY,
+
+    // Arithmetic
+    ADC,
+    SBC,
+    INC,
+    INX,
+    INY,
+    DEC,
+    DEX,
+    DEY,
+
+    // Shift and Rotate
+    ASL,
+    LSR,
+    ROL,
+    ROR,
+    AND,
+    ORA,
+    EOR,
+
+    // Compare and Test Bit
+    CMP,
+    CPX,
+    CPY,
+    BIT,
+
+    // Branch
+    BCC,
+    BCS,
+    BNE,
+    BEQ,
+    BPL,
+    BMI,
+    BVC,
+    BVS,
+
+    // Transfer
+    TAX,
+    TXA,
+    TAY,
+    TYA,
+    TSX,
+    TXS,
+
+    // Stack
+    PHA,
+    PLA,
+    PHP,
+    PLP,
+
+    // Subroutines and Jump
+    JMP,
+    JSR,
+    RTS,
+    RTI,
+
+    // Set and Clear
+    CLC,
+    SEC,
+    CLD,
+    SED,
+    CLI,
+    SEI,
+    CLV,
+
+    // Misc
+    BRK,
+    NOP,
+}
+
+/// AddressMode captures the Address mode type with a corresponding
+/// operand of the appropriate bit length.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum AddressMode {
+    Accumulator,
+    Implied,
+    Immediate(u8),
+    Absolute(u16),
+    ZeroPage(u8),
+    Relative(i8),
+    Indirect(u16),
+    AbsoluteIndexedWithX(u16),
+    AbsoluteIndexedWithY(u16),
+    ZeroPageIndexedWithX(u8),
+    ZeroPageIndexedWithY(u8),
+    IndexedIndirect(u8),
+    IndirectIndexed(u8),
+}

--- a/src/cpu/mos6502/operations.rs
+++ b/src/cpu/mos6502/operations.rs
@@ -1,89 +1,91 @@
-#[derive(Copy, Clone, PartialEq, Debug)]
-/// Operation takes a mnemonic
-pub struct Operation<M, A> {
-    mnemonic: M,
-    address_mode: A,
-}
+extern crate parcel;
+use parcel::{ParseResult, Parser};
 
 // Load-Store
-pub struct LDA {}
-pub struct LDX {}
-pub struct LDY {}
-pub struct STA {}
-pub struct STX {}
-pub struct STY {}
+pub struct LDA;
+pub struct LDX;
+pub struct LDY;
+pub struct STA;
+pub struct STX;
+pub struct STY;
 
 // Arithmetic
-pub struct ADC {}
-pub struct SBC {}
-pub struct INC {}
-pub struct INX {}
-pub struct INY {}
-pub struct DEC {}
-pub struct DEX {}
-pub struct DEY {}
+pub struct ADC;
+pub struct SBC;
+pub struct INC;
+pub struct INX;
+pub struct INY;
+pub struct DEC;
+pub struct DEX;
+pub struct DEY;
 
 // Shift and Rotate
-pub struct ASL {}
-pub struct LSR {}
-pub struct ROL {}
-pub struct ROR {}
-pub struct AND {}
-pub struct ORA {}
-pub struct EOR {}
+pub struct ASL;
+pub struct LSR;
+pub struct ROL;
+pub struct ROR;
+pub struct AND;
+pub struct ORA;
+pub struct EOR;
 
 // Compare and Test Bit
-pub struct CMP {}
-pub struct CPX {}
-pub struct CPY {}
-pub struct BIT {}
+pub struct CMP;
+pub struct CPX;
+pub struct CPY;
+pub struct BIT;
 
 // Branch
-pub struct BCC {}
-pub struct BCS {}
-pub struct BNE {}
-pub struct BEQ {}
-pub struct BPL {}
-pub struct BMI {}
-pub struct BVC {}
-pub struct BVS {}
+pub struct BCC;
+pub struct BCS;
+pub struct BNE;
+pub struct BEQ;
+pub struct BPL;
+pub struct BMI;
+pub struct BVC;
+pub struct BVS;
 
 // Transfer
-pub struct TAX {}
-pub struct TXA {}
-pub struct TAY {}
-pub struct TYA {}
-pub struct TSX {}
-pub struct TXS {}
+pub struct TAX;
+pub struct TXA;
+pub struct TAY;
+pub struct TYA;
+pub struct TSX;
+pub struct TXS;
 
 // Stack Operations
-pub struct PHA {}
-pub struct PLA {}
-pub struct PHP {}
-pub struct PLP {}
+pub struct PHA;
+pub struct PLA;
+pub struct PHP;
+pub struct PLP;
 
 // Subroutines and Jump
-pub struct JMP {}
-pub struct JSR {}
-pub struct RTS {}
-pub struct RTI {}
+pub struct JMP;
+pub struct JSR;
+pub struct RTS;
+pub struct RTI;
 
 // Set and Clear
-pub struct CLC {}
-pub struct SEC {}
-pub struct CLD {}
-pub struct SED {}
-pub struct CLI {}
-pub struct SEI {}
-pub struct CLV {}
+pub struct CLC;
+pub struct SEC;
+pub struct CLD;
+pub struct SED;
+pub struct CLI;
+pub struct SEI;
+pub struct CLV;
 
 // Misc
-pub struct BRK {}
-pub struct NOP {}
+pub struct BRK;
+pub struct NOP;
+
+impl<'a> Parser<'a, &'a [u8], NOP> for NOP {
+    fn parse(&self, _: &'a [u8]) -> ParseResult<&'a [u8], NOP> {
+        todo!()
+    }
+}
 
 /// Address modes
-pub struct Accumulator();
-pub struct Implied();
+pub struct Accumulator;
+pub struct Implied;
 pub struct Immediate(u8);
 pub struct Absolute(u16);
 pub struct ZeroPage(u8);
@@ -95,3 +97,10 @@ pub struct ZeroPageIndexedWithX(u8);
 pub struct ZeroPageIndexedWithY(u8);
 pub struct IndexedIndirect(u8);
 pub struct IndirectIndexed(u8);
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+/// Operation takes a mnemonic
+pub struct Operation<M, A> {
+    mnemonic: M,
+    address_mode: A,
+}

--- a/src/cpu/mos6502/operations.rs
+++ b/src/cpu/mos6502/operations.rs
@@ -1,0 +1,97 @@
+#[derive(Copy, Clone, PartialEq, Debug)]
+/// Operation takes a mnemonic
+pub struct Operation<M, A> {
+    mnemonic: M,
+    address_mode: A,
+}
+
+// Load-Store
+pub struct LDA {}
+pub struct LDX {}
+pub struct LDY {}
+pub struct STA {}
+pub struct STX {}
+pub struct STY {}
+
+// Arithmetic
+pub struct ADC {}
+pub struct SBC {}
+pub struct INC {}
+pub struct INX {}
+pub struct INY {}
+pub struct DEC {}
+pub struct DEX {}
+pub struct DEY {}
+
+// Shift and Rotate
+pub struct ASL {}
+pub struct LSR {}
+pub struct ROL {}
+pub struct ROR {}
+pub struct AND {}
+pub struct ORA {}
+pub struct EOR {}
+
+// Compare and Test Bit
+pub struct CMP {}
+pub struct CPX {}
+pub struct CPY {}
+pub struct BIT {}
+
+// Branch
+pub struct BCC {}
+pub struct BCS {}
+pub struct BNE {}
+pub struct BEQ {}
+pub struct BPL {}
+pub struct BMI {}
+pub struct BVC {}
+pub struct BVS {}
+
+// Transfer
+pub struct TAX {}
+pub struct TXA {}
+pub struct TAY {}
+pub struct TYA {}
+pub struct TSX {}
+pub struct TXS {}
+
+// Stack Operations
+pub struct PHA {}
+pub struct PLA {}
+pub struct PHP {}
+pub struct PLP {}
+
+// Subroutines and Jump
+pub struct JMP {}
+pub struct JSR {}
+pub struct RTS {}
+pub struct RTI {}
+
+// Set and Clear
+pub struct CLC {}
+pub struct SEC {}
+pub struct CLD {}
+pub struct SED {}
+pub struct CLI {}
+pub struct SEI {}
+pub struct CLV {}
+
+// Misc
+pub struct BRK {}
+pub struct NOP {}
+
+/// Address modes
+pub struct Accumulator();
+pub struct Implied();
+pub struct Immediate(u8);
+pub struct Absolute(u16);
+pub struct ZeroPage(u8);
+pub struct Relative(i8);
+pub struct Indirect(u16);
+pub struct AbsoluteIndexedWithX(u16);
+pub struct AbsoluteIndexedWithY(u16);
+pub struct ZeroPageIndexedWithX(u8);
+pub struct ZeroPageIndexedWithY(u8);
+pub struct IndexedIndirect(u8);
+pub struct IndirectIndexed(u8);

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -1,0 +1,14 @@
+/// Address modes
+pub struct Accumulator;
+pub struct Implied;
+pub struct Immediate(u8);
+pub struct Absolute(u16);
+pub struct ZeroPage(u8);
+pub struct Relative(i8);
+pub struct Indirect(u16);
+pub struct AbsoluteIndexedWithX(u16);
+pub struct AbsoluteIndexedWithY(u16);
+pub struct ZeroPageIndexedWithX(u8);
+pub struct ZeroPageIndexedWithY(u8);
+pub struct IndexedIndirect(u8);
+pub struct IndirectIndexed(u8);

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -2,11 +2,13 @@ extern crate parcel;
 use crate::cpu::{Cyclable, Offset};
 use parcel::{MatchStatus, ParseResult, Parser};
 
+#[derive(Clone, Copy)]
 pub struct Accumulator;
 
 /// Implied address address mode. This is signified by no address mode
 /// arguments. An example instruction with an implied address mode would be.
 /// `nop`
+#[derive(Clone, Copy)]
 pub struct Implied;
 
 impl Cyclable for Implied {}
@@ -23,14 +25,35 @@ impl<'a> Parser<'a, &'a [u8], Implied> for Implied {
     }
 }
 
+#[derive(Clone, Copy)]
 pub struct Immediate(u8);
+
+#[derive(Clone, Copy)]
 pub struct Absolute(u16);
+
+#[derive(Clone, Copy)]
 pub struct ZeroPage(u8);
+
+#[derive(Clone, Copy)]
 pub struct Relative(i8);
+
+#[derive(Clone, Copy)]
 pub struct Indirect(u16);
+
+#[derive(Clone, Copy)]
 pub struct AbsoluteIndexedWithX(u16);
+
+#[derive(Clone, Copy)]
 pub struct AbsoluteIndexedWithY(u16);
+
+#[derive(Clone, Copy)]
 pub struct ZeroPageIndexedWithX(u8);
+
+#[derive(Clone, Copy)]
 pub struct ZeroPageIndexedWithY(u8);
+
+#[derive(Clone, Copy)]
 pub struct IndexedIndirect(u8);
+
+#[derive(Clone, Copy)]
 pub struct IndirectIndexed(u8);

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use crate::cpu::Cyclable;
+use crate::cpu::{Cyclable, Offset};
 use parcel::{MatchStatus, ParseResult, Parser};
 
 pub struct Accumulator;
@@ -10,6 +10,12 @@ pub struct Accumulator;
 pub struct Implied;
 
 impl Cyclable for Implied {}
+
+impl Offset for Implied {
+    fn offset(&self) -> usize {
+        0
+    }
+}
 
 impl<'a> Parser<'a, &'a [u8], Implied> for Implied {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Implied> {

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -1,6 +1,22 @@
-/// Address modes
+extern crate parcel;
+use crate::cpu::Cyclable;
+use parcel::{MatchStatus, ParseResult, Parser};
+
 pub struct Accumulator;
+
+/// Implied address address mode. This is signified by no address mode
+/// arguments. An example instruction with an implied address mode would be.
+/// `nop`
 pub struct Implied;
+
+impl Cyclable for Implied {}
+
+impl<'a> Parser<'a, &'a [u8], Implied> for Implied {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Implied> {
+        Ok(MatchStatus::Match((input, Implied)))
+    }
+}
+
 pub struct Immediate(u8);
 pub struct Absolute(u16);
 pub struct ZeroPage(u8);

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use crate::cpu::Cyclable;
+use crate::cpu::{Cyclable, Offset};
 use parcel::{ParseResult, Parser};
 
 // Load-Store
@@ -82,6 +82,7 @@ pub struct BRK;
 pub struct NOP;
 
 impl Cyclable for NOP {}
+impl Offset for NOP {}
 
 impl From<NOP> for u8 {
     fn from(_: NOP) -> Self {

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -77,30 +77,16 @@ pub struct CLV;
 pub struct BRK;
 pub struct NOP;
 
-impl<'a> Parser<'a, &'a [u8], NOP> for NOP {
-    fn parse(&self, _: &'a [u8]) -> ParseResult<&'a [u8], NOP> {
-        todo!()
+impl From<NOP> for u8 {
+    fn from(_: NOP) -> Self {
+        0xea
     }
 }
 
-/// Address modes
-pub struct Accumulator;
-pub struct Implied;
-pub struct Immediate(u8);
-pub struct Absolute(u16);
-pub struct ZeroPage(u8);
-pub struct Relative(i8);
-pub struct Indirect(u16);
-pub struct AbsoluteIndexedWithX(u16);
-pub struct AbsoluteIndexedWithY(u16);
-pub struct ZeroPageIndexedWithX(u8);
-pub struct ZeroPageIndexedWithY(u8);
-pub struct IndexedIndirect(u8);
-pub struct IndirectIndexed(u8);
-
-#[derive(Copy, Clone, PartialEq, Debug)]
-/// Operation takes a mnemonic
-pub struct Operation<M, A> {
-    mnemonic: M,
-    address_mode: A,
+impl<'a> Parser<'a, &'a [u8], NOP> for NOP {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], NOP> {
+        parcel::parsers::byte::expect_byte(NOP.into())
+            .map(|_| NOP)
+            .parse(input)
+    }
 }

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -1,4 +1,5 @@
 extern crate parcel;
+use crate::cpu::Cyclable;
 use parcel::{ParseResult, Parser};
 
 // Load-Store
@@ -75,7 +76,12 @@ pub struct CLV;
 
 // Misc
 pub struct BRK;
+
+/// Represents a `nop` instruction, only implemented for the implied address
+/// mode and functions as a "No Operation".
 pub struct NOP;
+
+impl Cyclable for NOP {}
 
 impl From<NOP> for u8 {
     fn from(_: NOP) -> Self {

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -3,82 +3,183 @@ use crate::cpu::{Cyclable, Offset};
 use parcel::{ParseResult, Parser};
 
 // Load-Store
+#[derive(Clone, Copy)]
 pub struct LDA;
+
+#[derive(Clone, Copy)]
 pub struct LDX;
+
+#[derive(Clone, Copy)]
 pub struct LDY;
+
+#[derive(Clone, Copy)]
 pub struct STA;
+
+#[derive(Clone, Copy)]
 pub struct STX;
+
+#[derive(Clone, Copy)]
 pub struct STY;
 
 // Arithmetic
+#[derive(Clone, Copy)]
 pub struct ADC;
+
+#[derive(Clone, Copy)]
 pub struct SBC;
+
+#[derive(Clone, Copy)]
 pub struct INC;
+
+#[derive(Clone, Copy)]
 pub struct INX;
+
+#[derive(Clone, Copy)]
 pub struct INY;
+
+#[derive(Clone, Copy)]
 pub struct DEC;
+
+#[derive(Clone, Copy)]
 pub struct DEX;
+
+#[derive(Clone, Copy)]
 pub struct DEY;
 
 // Shift and Rotate
+#[derive(Clone, Copy)]
 pub struct ASL;
+
+#[derive(Clone, Copy)]
 pub struct LSR;
+
+#[derive(Clone, Copy)]
 pub struct ROL;
+
+#[derive(Clone, Copy)]
 pub struct ROR;
+
+#[derive(Clone, Copy)]
 pub struct AND;
+
+#[derive(Clone, Copy)]
 pub struct ORA;
+
+#[derive(Clone, Copy)]
 pub struct EOR;
 
 // Compare and Test Bit
+#[derive(Clone, Copy)]
 pub struct CMP;
+
+#[derive(Clone, Copy)]
 pub struct CPX;
+
+#[derive(Clone, Copy)]
 pub struct CPY;
+
+#[derive(Clone, Copy)]
 pub struct BIT;
 
 // Branch
+#[derive(Clone, Copy)]
 pub struct BCC;
+
+#[derive(Clone, Copy)]
 pub struct BCS;
+
+#[derive(Clone, Copy)]
 pub struct BNE;
+
+#[derive(Clone, Copy)]
 pub struct BEQ;
+
+#[derive(Clone, Copy)]
 pub struct BPL;
+
+#[derive(Clone, Copy)]
 pub struct BMI;
+
+#[derive(Clone, Copy)]
 pub struct BVC;
+
+#[derive(Clone, Copy)]
 pub struct BVS;
 
 // Transfer
+#[derive(Clone, Copy)]
 pub struct TAX;
+
+#[derive(Clone, Copy)]
 pub struct TXA;
+
+#[derive(Clone, Copy)]
 pub struct TAY;
+
+#[derive(Clone, Copy)]
 pub struct TYA;
+
+#[derive(Clone, Copy)]
 pub struct TSX;
+
+#[derive(Clone, Copy)]
 pub struct TXS;
 
 // Stack Operations
+#[derive(Clone, Copy)]
 pub struct PHA;
+
+#[derive(Clone, Copy)]
 pub struct PLA;
+
+#[derive(Clone, Copy)]
 pub struct PHP;
+
+#[derive(Clone, Copy)]
 pub struct PLP;
 
 // Subroutines and Jump
+#[derive(Clone, Copy)]
 pub struct JMP;
+
+#[derive(Clone, Copy)]
 pub struct JSR;
+
+#[derive(Clone, Copy)]
 pub struct RTS;
+
+#[derive(Clone, Copy)]
 pub struct RTI;
 
 // Set and Clear
+#[derive(Clone, Copy)]
 pub struct CLC;
+
+#[derive(Clone, Copy)]
 pub struct SEC;
+
+#[derive(Clone, Copy)]
 pub struct CLD;
+
+#[derive(Clone, Copy)]
 pub struct SED;
+
+#[derive(Clone, Copy)]
 pub struct CLI;
+
+#[derive(Clone, Copy)]
 pub struct SEI;
+
+#[derive(Clone, Copy)]
 pub struct CLV;
 
 // Misc
+#[derive(Clone, Copy)]
 pub struct BRK;
 
 /// Represents a `nop` instruction, only implemented for the implied address
 /// mode and functions as a "No Operation".
+#[derive(Clone, Copy)]
 pub struct NOP;
 
 impl Cyclable for NOP {}

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -28,6 +28,16 @@ where
     }
 }
 
+impl<M, A> Cyclable for Operation<M, A>
+where
+    M: Cyclable + Offset,
+    A: Cyclable + Offset,
+{
+    fn cycles(&self) -> usize {
+        self.mnemonic.cycles() + self.address_mode.cycles()
+    }
+}
+
 impl<'a> Parser<'a, &'a [u8], Operation<mnemonic::NOP, address_mode::Implied>>
     for Operation<mnemonic::NOP, address_mode::Implied>
 {

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,4 +1,6 @@
+extern crate parcel;
 use crate::cpu::{Cyclable, Offset};
+use parcel::{ParseResult, Parser};
 
 pub mod address_mode;
 pub mod mnemonic;
@@ -11,4 +13,31 @@ where
 {
     mnemonic: M,
     address_mode: A,
+}
+
+impl<M, A> Operation<M, A>
+where
+    M: Cyclable + Offset,
+    A: Cyclable + Offset,
+{
+    pub fn new(mnemonic: M, address_mode: A) -> Self {
+        Operation {
+            mnemonic,
+            address_mode,
+        }
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], Operation<mnemonic::NOP, address_mode::Implied>>
+    for Operation<mnemonic::NOP, address_mode::Implied>
+{
+    fn parse(
+        &self,
+        input: &'a [u8],
+    ) -> ParseResult<&'a [u8], Operation<mnemonic::NOP, address_mode::Implied>> {
+        mnemonic::NOP
+            .and_then(|_| address_mode::Implied)
+            .map(|am| Operation::new(mnemonic::NOP, am))
+            .parse(input)
+    }
 }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -5,11 +5,13 @@ use parcel::{ParseResult, Parser};
 pub mod address_mode;
 pub mod mnemonic;
 
-/// Operation takes a mnemonic
+/// Operation takes a mnemonic and address mode as arguments for sizing
+/// and operations.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Operation<M, A>
 where
-    M: Cyclable + Offset,
-    A: Cyclable + Offset,
+    M: Cyclable + Offset + Copy,
+    A: Cyclable + Offset + Copy,
 {
     mnemonic: M,
     address_mode: A,
@@ -17,8 +19,8 @@ where
 
 impl<M, A> Operation<M, A>
 where
-    M: Cyclable + Offset,
-    A: Cyclable + Offset,
+    M: Cyclable + Offset + Copy,
+    A: Cyclable + Offset + Copy,
 {
     pub fn new(mnemonic: M, address_mode: A) -> Self {
         Operation {
@@ -30,11 +32,21 @@ where
 
 impl<M, A> Cyclable for Operation<M, A>
 where
-    M: Cyclable + Offset,
-    A: Cyclable + Offset,
+    M: Cyclable + Offset + Copy,
+    A: Cyclable + Offset + Copy,
 {
     fn cycles(&self) -> usize {
         self.mnemonic.cycles() + self.address_mode.cycles()
+    }
+}
+
+impl<M, A> Offset for Operation<M, A>
+where
+    M: Cyclable + Offset + Copy,
+    A: Cyclable + Offset + Copy,
+{
+    fn offset(&self) -> usize {
+        self.mnemonic.offset() + self.address_mode.offset()
     }
 }
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,9 +1,14 @@
+use crate::cpu::{Cyclable, Offset};
+
 pub mod address_mode;
 pub mod mnemonic;
 
-#[derive(Copy, Clone, PartialEq, Debug)]
 /// Operation takes a mnemonic
-pub struct Operation<M, A> {
+pub struct Operation<M, A>
+where
+    M: Cyclable + Offset,
+    A: Cyclable + Offset,
+{
     mnemonic: M,
     address_mode: A,
 }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,0 +1,9 @@
+pub mod address_mode;
+pub mod mnemonic;
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+/// Operation takes a mnemonic
+pub struct Operation<M, A> {
+    mnemonic: M,
+    address_mode: A,
+}

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1,0 +1,31 @@
+use crate::address_map::memory::{Memory, ReadOnly};
+use crate::cpu::{mos6502::MOS6502, register::Register, CPU};
+
+#[test]
+fn should_cycle_on_nop_operation() {
+    let nop_sled_start: u16 = 0x6000;
+    let nop_sled_end: u16 = 0x7000;
+    let mut nop_sled = Vec::<u8>::new();
+    nop_sled.resize((nop_sled_end - nop_sled_start) as usize, 0xea);
+
+    let mut cpu = MOS6502::default().reset().unwrap();
+    cpu.address_map = cpu
+        .address_map
+        .register(
+            nop_sled_start..nop_sled_end,
+            Box::new(Memory::<ReadOnly>::new(nop_sled_start, nop_sled_end).load(nop_sled)),
+        )
+        .unwrap();
+
+    cpu.pc = cpu.pc.write(0x6000);
+
+    // validate first step execs
+    let state = cpu.step();
+    assert_eq!(1, state.remaining);
+    assert_eq!(0x6001, state.cpu.pc.read());
+
+    // run 2 more cycles and validate next nop is picked up
+    let state = state.step().step();
+    assert_eq!(1, state.remaining);
+    assert_eq!(0x6002, state.cpu.pc.read());
+}

--- a/src/cpu/register.rs
+++ b/src/cpu/register.rs
@@ -114,7 +114,7 @@ impl Into<u8> for ProcessorStatus {
         ps |= (self.decimal as u8) << 3;
         ps |= (self.interrupt_disable as u8) << 2;
         ps |= (self.zero as u8) << 1;
-        ps |= (self.carry as u8) << 0;
+        ps |= self.carry as u8;
         ps
     }
 }


### PR DESCRIPTION
# Introduction
Begin handling operation processing for the CPU. This includes:
- stubbing out implementations of a steppable mos6502 cpu
  - Definitions of address modes and mnemonics for this
  - Definitions of how these compose into operations
    - Parser implementations for the operations
    - Executable actions for a test subset of these operations
  - Traits to communicate the cycle time and offset in bytes to step the program counter for each op.

# Linked Issues
#14 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
