### PR TITLE
Implement chainable register update methods

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -148,13 +148,13 @@ impl CPU<MOS6502> for StepState<MOS6502> {
             .unwrap()
             .unwrap();
 
-            // run the operation to transform the cpu state
-            let mut mos = mos.execute(oper);
-
             // set pc offsets and cycles as defined by operation.
             let offset = oper.offset() as u16;
-            mos.pc = mos.pc.write(pc + offset);
-            StepState::new(oper.cycles(), mos)
+            StepState::new(
+                oper.cycles(),
+                mos.execute(oper)
+                    .with_pc_register(ProgramCounter::with_value(pc + offset)),
+            )
         }
     }
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -22,6 +22,14 @@ trait Execute<T> {
     fn execute(self, operation: T) -> Self;
 }
 
+/// Represets each type of general purpose register available in the mos6502.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GPRegister {
+    ACC,
+    X,
+    Y,
+}
+
 /// MOS6502 represents the 6502 CPU
 #[derive(Debug)]
 pub struct MOS6502 {
@@ -54,6 +62,38 @@ impl MOS6502 {
 
         cpu.pc = ProgramCounter::default().write(u16::from_le_bytes([lsb, msb]));
         StepState::new(6, cpu)
+    }
+
+    /// Provides a wrapper to update a general-purpose register in a way that
+    /// returns the entire cpu after modification.
+    pub fn with_gp_register(mut self, reg_type: GPRegister, reg: GeneralPurpose) -> Self {
+        match reg_type {
+            GPRegister::ACC => self.acc = reg,
+            GPRegister::X => self.x = reg,
+            GPRegister::Y => self.y = reg,
+        };
+        self
+    }
+
+    /// Provides a wrapper to update the stack-pointer register in a way that
+    /// returns the entire cpu after modification.
+    pub fn with_sp_register(mut self, reg: StackPointer) -> Self {
+        self.sp = reg;
+        self
+    }
+
+    /// Provides a wrapper to update the program-counter register in a way that
+    /// returns the entire cpu after modification.
+    pub fn with_pc_register(mut self, reg: ProgramCounter) -> Self {
+        self.pc = reg;
+        self
+    }
+
+    /// Provides a wrapper to update the processor-status register in a way that
+    /// returns the entire cpu after modification.
+    pub fn update_ps_register(mut self, reg: ProcessorStatus) -> Self {
+        self.ps = reg;
+        self
     }
 }
 

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -91,7 +91,7 @@ impl MOS6502 {
 
     /// Provides a wrapper to update the processor-status register in a way that
     /// returns the entire cpu after modification.
-    pub fn update_ps_register(mut self, reg: ProcessorStatus) -> Self {
+    pub fn with_ps_register(mut self, reg: ProcessorStatus) -> Self {
         self.ps = reg;
         self
     }

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -1,5 +1,5 @@
 use crate::address_map::memory::{Memory, ReadOnly};
-use crate::cpu::{mos6502::MOS6502, register::Register, CPU};
+use crate::cpu::{mos6502::MOS6502, register, register::Register, CPU};
 
 #[test]
 fn should_cycle_on_nop_operation() {
@@ -8,7 +8,10 @@ fn should_cycle_on_nop_operation() {
     let mut nop_sled = Vec::<u8>::new();
     nop_sled.resize((nop_sled_end - nop_sled_start) as usize, 0xea);
 
-    let mut cpu = MOS6502::default().reset().unwrap();
+    let mut cpu = MOS6502::default()
+        .reset()
+        .unwrap()
+        .with_pc_register(register::ProgramCounter::with_value(0x6000));
     cpu.address_map = cpu
         .address_map
         .register(
@@ -16,8 +19,6 @@ fn should_cycle_on_nop_operation() {
             Box::new(Memory::<ReadOnly>::new(nop_sled_start, nop_sled_end).load(nop_sled)),
         )
         .unwrap();
-
-    cpu.pc = cpu.pc.write(0x6000);
 
     // validate first step execs
     let state = cpu.step();

--- a/src/cpu/register.rs
+++ b/src/cpu/register.rs
@@ -1,6 +1,7 @@
 pub trait Register<R, W> {
     fn read(&self) -> R;
     fn write(self, value: W) -> Self;
+    fn with_value(value: W) -> Self;
 }
 
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
@@ -13,6 +14,10 @@ impl Register<u8, u8> for GeneralPurpose {
         self.inner
     }
     fn write(self, value: u8) -> Self {
+        Self::with_value(value)
+    }
+
+    fn with_value(value: u8) -> Self {
         Self { inner: value }
     }
 }
@@ -26,8 +31,11 @@ impl Register<u16, u16> for ProgramCounter {
     fn read(&self) -> u16 {
         self.inner
     }
-
     fn write(self, value: u16) -> Self {
+        Self::with_value(value)
+    }
+
+    fn with_value(value: u16) -> Self {
         Self { inner: value }
     }
 }
@@ -51,6 +59,10 @@ impl Register<u16, u8> for StackPointer {
     }
 
     fn write(self, value: u8) -> Self {
+        Self::with_value(value)
+    }
+
+    fn with_value(value: u8) -> Self {
         Self { inner: value }
     }
 }
@@ -99,7 +111,12 @@ impl Register<u8, u8> for ProcessorStatus {
     fn read(&self) -> u8 {
         self.clone().into()
     }
+
     fn write(self, _value: u8) -> Self {
+        todo!()
+    }
+
+    fn with_value(_value: u8) -> Self {
         todo!()
     }
 }


### PR DESCRIPTION
# Introduction
Adds chained register update methods to make changes to register state chainable.

## Example

```rust
StepState::new(
    oper.cycles(),
    mos.execute(oper)
        .with_pc_register(ProgramCounter::with_value(pc + offset)),
)
```

# Linked Issues
resolves #20 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
