### PR TITLE
Implement TryFrom for sized bytes for an Operation

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -1,5 +1,5 @@
 extern crate parcel;
-use parcel::Parser;
+use std::convert::TryFrom;
 
 use crate::{
     address_map::{
@@ -141,12 +141,7 @@ impl CPU<MOS6502> for StepState<MOS6502> {
             ];
 
             // Parse correct operation
-            let oper = match opcodes[0] {
-                0xEA => Operation::new(mnemonic::NOP, address_mode::Implied).parse(&opcodes),
-                _ => Err(format!("unimplemented opcode: {}", opcodes[0])),
-            }
-            .unwrap()
-            .unwrap();
+            let oper: Operation<_, _> = TryFrom::try_from(&opcodes).unwrap();
 
             // set pc offsets and cycles as defined by operation.
             let offset = oper.offset() as u16;

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -2,13 +2,13 @@ extern crate parcel;
 use crate::cpu::{Cyclable, Offset};
 use parcel::{MatchStatus, ParseResult, Parser};
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Accumulator;
 
 /// Implied address address mode. This is signified by no address mode
 /// arguments. An example instruction with an implied address mode would be.
 /// `nop`
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Implied;
 
 impl Cyclable for Implied {}
@@ -25,35 +25,35 @@ impl<'a> Parser<'a, &'a [u8], Implied> for Implied {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Immediate(u8);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Absolute(u16);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ZeroPage(u8);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Relative(i8);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Indirect(u16);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithX(u16);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithY(u16);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ZeroPageIndexedWithX(u8);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ZeroPageIndexedWithY(u8);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IndexedIndirect(u8);
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IndirectIndexed(u8);

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -3,183 +3,183 @@ use crate::cpu::{Cyclable, Offset};
 use parcel::{ParseResult, Parser};
 
 // Load-Store
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LDA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LDX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LDY;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct STA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct STX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct STY;
 
 // Arithmetic
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ADC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SBC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct INC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct INX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct INY;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DEC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DEX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DEY;
 
 // Shift and Rotate
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ASL;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LSR;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ROL;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ROR;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AND;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ORA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct EOR;
 
 // Compare and Test Bit
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CMP;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CPX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CPY;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BIT;
 
 // Branch
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BCC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BCS;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BNE;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BEQ;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BPL;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BMI;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BVC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BVS;
 
 // Transfer
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TAX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TXA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TAY;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TYA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TSX;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TXS;
 
 // Stack Operations
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PHA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PLA;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PHP;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PLP;
 
 // Subroutines and Jump
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct JMP;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct JSR;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RTS;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RTI;
 
 // Set and Clear
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CLC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SEC;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CLD;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SED;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CLI;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SEI;
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CLV;
 
 // Misc
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct BRK;
 
 /// Represents a `nop` instruction, only implemented for the implied address
 /// mode and functions as a "No Operation".
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct NOP;
 
 impl Cyclable for NOP {}

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,17 +1,21 @@
 extern crate parcel;
 use crate::cpu::{Cyclable, Offset};
 use parcel::{ParseResult, Parser};
+use std::fmt::Debug;
 
 pub mod address_mode;
 pub mod mnemonic;
+
+#[cfg(test)]
+mod tests;
 
 /// Operation takes a mnemonic and address mode as arguments for sizing
 /// and operations.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Operation<M, A>
 where
-    M: Cyclable + Offset + Copy,
-    A: Cyclable + Offset + Copy,
+    M: Cyclable + Offset + Copy + Debug + PartialEq,
+    A: Cyclable + Offset + Copy + Debug + PartialEq,
 {
     mnemonic: M,
     address_mode: A,
@@ -19,8 +23,8 @@ where
 
 impl<M, A> Operation<M, A>
 where
-    M: Cyclable + Offset + Copy,
-    A: Cyclable + Offset + Copy,
+    M: Cyclable + Offset + Copy + Debug + PartialEq,
+    A: Cyclable + Offset + Copy + Debug + PartialEq,
 {
     pub fn new(mnemonic: M, address_mode: A) -> Self {
         Operation {
@@ -32,8 +36,8 @@ where
 
 impl<M, A> Cyclable for Operation<M, A>
 where
-    M: Cyclable + Offset + Copy,
-    A: Cyclable + Offset + Copy,
+    M: Cyclable + Offset + Copy + Debug + PartialEq,
+    A: Cyclable + Offset + Copy + Debug + PartialEq,
 {
     fn cycles(&self) -> usize {
         self.mnemonic.cycles() + self.address_mode.cycles()
@@ -42,11 +46,21 @@ where
 
 impl<M, A> Offset for Operation<M, A>
 where
-    M: Cyclable + Offset + Copy,
-    A: Cyclable + Offset + Copy,
+    M: Cyclable + Offset + Copy + Debug + PartialEq,
+    A: Cyclable + Offset + Copy + Debug + PartialEq,
 {
     fn offset(&self) -> usize {
         self.mnemonic.offset() + self.address_mode.offset()
+    }
+}
+
+impl std::convert::TryFrom<&[u8; 3]> for Operation<mnemonic::NOP, address_mode::Implied> {
+    type Error = String;
+    fn try_from(values: &[u8; 3]) -> std::result::Result<Self, Self::Error> {
+        match Operation::new(mnemonic::NOP, address_mode::Implied).parse(values) {
+            Ok(parcel::MatchStatus::Match((_, op))) => Ok(op),
+            _ => Err(format!("No match found for {}", values[0])),
+        }
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -1,0 +1,14 @@
+extern crate parcel;
+use crate::cpu::mos6502::operations::*;
+use std::convert::TryFrom;
+
+#[test]
+fn should_parse_ea_instruction_from_bytecode() {
+    let bytecode = [0xea, 0x00, 0x00];
+    let operation = TryFrom::try_from(&bytecode);
+
+    assert_eq!(
+        Ok(Operation::new(mnemonic::NOP, address_mode::Implied)),
+        operation
+    );
+}

--- a/src/cpu/tests/mod.rs
+++ b/src/cpu/tests/mod.rs
@@ -1,4 +1,1 @@
-#[test]
-fn it_works() {
-    assert_eq!(2, 1 + 1);
-}
+

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,1 @@
-#[test]
-fn it_works() {
-    assert_eq!(2 + 2, 4);
-}
+


### PR DESCRIPTION
# Introduction
Implements a TryFrom method for `&[u8; 3]` that functions to parse a byte input instruction into it's corresponding operation. This  simplifies the process of matching input. A simple example being the following:

```rust
let bytecode = [0xea, 0x00, 0x00];
let operation = TryFrom::try_from(&bytecode);

assert_eq!(
    Ok(Operation::new(mnemonic::NOP, address_mode::Implied)),
    operation
);
```

This hides the process of parsing from the CPU and instead allows this to entirely be encapsulated on the Operation making it much easier to slowly implement operations over time without making a bloated match which was what was in place previously.

# Linked Issues
resolves #23 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
