### PR TITLE
Add instruction parser wrappers

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -18,7 +18,7 @@ use register::{GeneralPurpose, ProcessorStatus, ProgramCounter, StackPointer};
 pub mod operations;
 use operations::Operation;
 
-trait Execute<T> {
+pub trait Execute<T> {
     fn execute(self, cpu: T) -> T;
 }
 


### PR DESCRIPTION
# Introduction
This PR includes a few quality of life improvements for defining the instruction set parsers by cutting down the amount of boiler plate needed to parser different concrete instructions to Operations so they match the same concrete type. This PR hides this conversion behind a macro so the behaviour of the parser is easier to read.

# Linked Issues
#15 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
