### PR TITLE
Implement iterator for cpu types

### DIFF
--- a/src/address_map/memory.rs
+++ b/src/address_map/memory.rs
@@ -17,14 +17,17 @@ impl std::fmt::Display for MemoryErr {
 
 /// Represents a ReadOnly type of memory. This is entirely used for
 /// typechecking and has no other practical uses.
-pub struct ReadOnly {}
+#[derive(Clone, Copy)]
+pub struct ReadOnly;
 
 /// Represents a ReadWrite type of memory. This is entirely used for
 /// typechecking and has no other practical uses.
-pub struct ReadWrite {}
+#[derive(Clone, Copy)]
+pub struct ReadWrite;
 
 /// Represents an addressable segment of memory, be it RAM or ROM.
 #[allow(dead_code)]
+#[derive(Clone)]
 pub struct Memory<T> {
     mem_type: PhantomData<T>,
     start_address: u16,

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -18,6 +18,7 @@ pub trait CPU<T> {
 }
 
 /// Stores state between cycles.
+#[derive(Clone)]
 pub struct StepState<T> {
     remaining: usize, // Remaining cycles in operation
     cpu: T,

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -49,6 +49,12 @@ impl<T> StepState<T> {
     }
 }
 
+impl<T> From<T> for StepState<T> {
+    fn from(src: T) -> Self {
+        StepState::new(1, src)
+    }
+}
+
 impl<T> From<StepState<T>> for (usize, T) {
     fn from(stepstate: StepState<T>) -> Self {
         (stepstate.remaining, stepstate.cpu)

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -163,21 +163,32 @@ impl IntoIterator for MOS6502 {
     fn into_iter(self) -> Self::IntoIter {
         let cpu_state = StepState::new(1, self);
 
-        CPUIntoIterator { cpu_state }
+        CPUIntoIterator { state: cpu_state }
+    }
+}
+
+impl IntoIterator for StepState<MOS6502> {
+    type Item = StepState<MOS6502>;
+    type IntoIter = CPUIntoIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let cpu_state = self;
+
+        CPUIntoIterator { state: cpu_state }
     }
 }
 
 pub struct CPUIntoIterator {
-    cpu_state: StepState<MOS6502>,
+    state: StepState<MOS6502>,
 }
 
 impl Iterator for CPUIntoIterator {
     type Item = StepState<MOS6502>;
 
     fn next(&mut self) -> Option<StepState<MOS6502>> {
-        let cpu = self.cpu_state.clone();
+        let cpu = self.state.clone();
         let new_state = cpu.step();
-        self.cpu_state = new_state.clone();
+        self.state = new_state.clone();
 
         Some(new_state)
     }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -31,7 +31,7 @@ pub enum GPRegister {
 }
 
 /// MOS6502 represents the 6502 CPU
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MOS6502 {
     address_map: AddressMap<u16>,
     pub acc: GeneralPurpose,
@@ -153,5 +153,32 @@ impl CPU<MOS6502> for StepState<MOS6502> {
                 executed_state.with_pc_register(ProgramCounter::with_value(espc + offset)),
             )
         }
+    }
+}
+
+impl IntoIterator for MOS6502 {
+    type Item = StepState<MOS6502>;
+    type IntoIter = CPUIntoIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let cpu_state = StepState::new(1, self);
+
+        CPUIntoIterator { cpu_state }
+    }
+}
+
+pub struct CPUIntoIterator {
+    cpu_state: StepState<MOS6502>,
+}
+
+impl Iterator for CPUIntoIterator {
+    type Item = StepState<MOS6502>;
+
+    fn next(&mut self) -> Option<StepState<MOS6502>> {
+        let cpu = self.cpu_state.clone();
+        let new_state = cpu.step();
+        self.cpu_state = new_state.clone();
+
+        Some(new_state)
     }
 }


### PR DESCRIPTION
# Introduction
This PR implements Iterators for the mos6502 cpu so that states can be stepped through using the very expressive Iterators constructs.

## Example

The below example shows a cpu iterating through 5 cycles and collecting that state into a vector over time.

```rust
let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
    .into_iter()
    .take(5)
    .collect();

assert_eq!(1, states.first().unwrap().remaining);
assert_eq!(0x6001, states.first().unwrap().cpu.pc.read());

assert_eq!(0, states.last().unwrap().remaining);
assert_eq!(0x6000, states.last().unwrap().cpu.pc.read());
```

# Linked Issues
#19
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
