### PR TITLE
Add a register_address_space to MOS6502 CPU to fit the builder pattern

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -55,7 +55,32 @@ impl MOS6502 {
         cpu
     }
 
-    /// attempts to wrap address space registration for the sake of chainability.
+    /// Functions as a wrapper around the `with_addressmap` and `register`
+    /// methods in a way that conforms to the builder pattern and facilitates
+    /// chainability of the registration. As such this method _can_ fail and
+    /// will forward the errors from the above methods in any case that it
+    /// fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use mos6502_emulator::address_map::{
+    ///     memory::{Memory, ReadOnly},
+    ///     Addressable,
+    /// };
+    /// use mos6502_emulator::cpu::mos6502::MOS6502;
+    ///
+    /// let (start_addr, stop_addr) = (0x6000, 0x7000);
+    /// let nop_sled = [0xea; 0x7000 - 0x6000].to_vec();
+    ///
+    /// assert!(
+    ///     MOS6502::default()
+    ///         .register_address_space(
+    ///             start_addr..stop_addr,
+    ///             Memory::<ReadOnly>::new(0x6000, 0x7000).load(nop_sled),
+    ///         ).is_ok()
+    ///     )
+    /// ```
     pub fn register_address_space(
         mut self,
         space: Range<u16>,

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -1,5 +1,6 @@
 extern crate parcel;
 use std::convert::TryFrom;
+use std::ops::Range;
 
 use crate::{
     address_map::{
@@ -52,6 +53,18 @@ impl MOS6502 {
         let mut cpu = Self::default();
         cpu.address_map = am;
         cpu
+    }
+
+    /// attempts to wrap address space registration for the sake of chainability.
+    pub fn register_address_space(
+        mut self,
+        space: Range<u16>,
+        addr_space: impl Addressable<u16> + 'static,
+    ) -> Result<Self, String> {
+        let am = self.address_map;
+        self.address_map = am.register(space, Box::new(addr_space))?;
+
+        Ok(self)
     }
 
     /// emulates the reset process of the CPU.

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -15,7 +15,7 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
         nop_sled[index] = val;
     }
 
-    let cpu = MOS6502::default()
+    MOS6502::default()
         .reset()
         .unwrap()
         .with_pc_register(register::ProgramCounter::with_value(start_addr))
@@ -23,19 +23,17 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
             start_addr..stop_addr,
             Memory::<ReadOnly>::new(0x6000, 0x7000).load(nop_sled),
         )
-        .unwrap();
-    cpu
+        .unwrap()
 }
 
 #[test]
 fn should_cycle_on_nop_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![]);
-
-    // validate first step execs
     let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
         .into_iter()
         .take(3)
         .collect();
+
     assert_eq!(1, states.first().unwrap().remaining);
     assert_eq!(0x6001, states.first().unwrap().cpu.pc.read());
 
@@ -47,7 +45,6 @@ fn should_cycle_on_nop_implied_operation() {
 #[test]
 fn should_cycle_on_lda_immediate_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff]);
-
     let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
         .into_iter()
         .take(2)
@@ -82,7 +79,6 @@ fn should_cycle_on_sta_absolute_operation() {
 #[test]
 fn should_cycle_on_jmp_absolute_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0xea, 0x4c, 0x50, 0x60]);
-
     let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
         .into_iter()
         .take(5)

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -9,9 +9,8 @@ use crate::cpu::{
 };
 
 fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
-    let (nop_sled_start, nop_sled_end) = (0x6000, 0x7000);
-    let mut nop_sled = Vec::<u8>::new();
-    nop_sled.resize((nop_sled_end - nop_sled_start) as usize, 0xea);
+    let (start_addr, stop_addr) = (0x6000, 0x7000);
+    let mut nop_sled = [0xea; 0x7000 - 0x6000].to_vec();
     for (index, val) in opcodes.into_iter().enumerate() {
         nop_sled[index] = val;
     }
@@ -19,10 +18,10 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
     let cpu = MOS6502::default()
         .reset()
         .unwrap()
-        .with_pc_register(register::ProgramCounter::with_value(0x6000))
+        .with_pc_register(register::ProgramCounter::with_value(start_addr))
         .register_address_space(
-            nop_sled_start..nop_sled_end,
-            Memory::<ReadOnly>::new(nop_sled_start, nop_sled_end).load(nop_sled),
+            start_addr..stop_addr,
+            Memory::<ReadOnly>::new(0x6000, 0x7000).load(nop_sled),
         )
         .unwrap();
     cpu


### PR DESCRIPTION
# Introduction
This PR adds an additional method to the MOS6502 type to allow an address_map to be passed in and registered, returning the CPU so that this can be chained inline as a constructor. This brings the CPU in line with other methods to make a builder pattern of defining a CPU possible.

## Example


```rust
use mos6502_emulator::address_map::{
    memory::{Memory, ReadOnly},
    Addressable,
};
use mos6502_emulator::cpu::mos6502::MOS6502;

let (start_addr, stop_addr) = (0x6000, 0x7000);
let nop_sled = [0xea; 0x7000 - 0x6000].to_vec();

assert!(MOS6502::default()
    .register_address_space(
        start_addr..stop_addr,
        Memory::<ReadOnly>::new(0x6000, 0x7000).load(nop_sled),
    )
    .is_ok())
```

# Linked Issues
resolves #33 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
