### PR TITLE
Implement jmp indirect instruction

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -69,8 +69,8 @@ pub struct ZeroPage(u8);
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Relative(i8);
 
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Indirect(u16);
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct Indirect(pub u16);
 
 impl Cyclable for Indirect {
     fn cycles(&self) -> usize {

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -72,6 +72,25 @@ pub struct Relative(i8);
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Indirect(u16);
 
+impl Cyclable for Indirect {
+    fn cycles(&self) -> usize {
+        4
+    }
+}
+impl Offset for Indirect {
+    fn offset(&self) -> usize {
+        2
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], Indirect> for Indirect {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], Indirect> {
+        parcel::take_n(any_byte(), 2)
+            .map(|b| Indirect(u16::from_le_bytes([b[0], b[1]])))
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithX(u16);
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -183,7 +183,7 @@ impl<'a> Parser<'a, &'a [u8], JMP> for JMP {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], JMP> {
         parcel::one_of(vec![
             parcel::parsers::byte::expect_byte(0x4c),
-            //parcel::parsers::byte::expect_byte(0x6c), // TODO: implemente indirect
+            parcel::parsers::byte::expect_byte(0x6c),
         ])
         .map(|_| JMP)
         .parse(input)

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -78,15 +78,24 @@ fn should_cycle_on_sta_absolute_operation() {
 
 #[test]
 fn should_cycle_on_jmp_absolute_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0xea, 0x4c, 0x50, 0x60]);
+    let cpu = generate_test_cpu_with_instructions(vec![0x4c, 0x50, 0x60]);
+    let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
+        .into_iter()
+        .take(3)
+        .collect();
+
+    assert_eq!(0, states.last().unwrap().remaining);
+    assert_eq!(0x6050, states.last().unwrap().cpu.pc.read());
+}
+
+#[test]
+fn should_cycle_on_jmp_indirect_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x6c, 0x50, 0x60]);
     let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
         .into_iter()
         .take(5)
         .collect();
 
-    assert_eq!(1, states.first().unwrap().remaining);
-    assert_eq!(0x6001, states.first().unwrap().cpu.pc.read());
-
     assert_eq!(0, states.last().unwrap().remaining);
-    assert_eq!(0x6050, states.last().unwrap().cpu.pc.read());
+    assert_eq!(0xeaea, states.last().unwrap().cpu.pc.read());
 }


### PR DESCRIPTION
# Introduction
This PR implements the jmp indirect instruction for the mos6502 cpu.

## Example

```rust
let cpu = generate_test_cpu_with_instructions(vec![0x6c, 0x50, 0x60]);
let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
    .into_iter()
    .take(5)
    .collect();

assert_eq!(0, states.last().unwrap().remaining);
assert_eq!(0xeaea, states.last().unwrap().cpu.pc.read())
```

# Linked Issues
resolves #37 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
