### PR TITLE
Implement microcode operations to capture state change between instructions

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -14,7 +14,7 @@ pub trait Offset {
 }
 
 pub trait CPU<T> {
-    fn step(self) -> StepState<T>;
+    fn step(self) -> T;
 }
 
 /// Stores state between cycles.

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -14,7 +14,7 @@ pub trait Offset {
 }
 
 pub trait CPU<T> {
-    fn step(self) -> T;
+    fn run(self, cycles: usize) -> StepState<T>;
 }
 
 /// Stores state between cycles.

--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -17,7 +17,9 @@ pub trait CPU<T> {
     fn run(self, cycles: usize) -> StepState<T>;
 }
 
-/// Stores state between cycles.
+/// Stores state between run invocations. The remaining field signifies noop cycles
+/// between instructions. This is to function as a placeholder when a run
+/// invocation returns while inbetween multi-cycle instructions.
 #[derive(Clone)]
 pub struct StepState<T> {
     remaining: usize, // Remaining cycles in operation
@@ -32,6 +34,7 @@ impl<T> StepState<T> {
         }
     }
 
+    /// Decrements the cycle count left on StepState by 1.
     pub fn decrement(self) -> Self {
         let remaining = self.remaining - 1;
         Self {

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -2,16 +2,14 @@
 //! include write operations to memory or registers and are the basic building
 //! blocks for an instruction implementation
 
+use crate::cpu::mos6502::register::ByteRegisters;
+
 /// An Enumerable type to store each microcode operation possible on the
 /// 6502 emulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
     WriteMemory(WriteMemory),
-    WriteAccRegister(WriteAccRegister),
-    WriteXRegister(WriteXRegister),
-    WriteYRegister(WriteYRegister),
-    WritePSRegister(WritePSRegister),
-    WriteSPRegister(WriteSPRegister),
+    Write8bitRegister(Write8bitRegister),
     WritePCRegister(WritePCRegister),
     IncPCRegister(IncPCRegister),
 }
@@ -32,27 +30,19 @@ impl WriteMemory {
 
 // 8-bit registers
 
-/// Represents a write of the specified 8-bit value to the A register.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteAccRegister(pub u8);
+/// Represents a write of the specified 8-bit value to one of the 8-bit
+/// registers as defined by the ByteRegisters value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Write8bitRegister {
+    pub register: ByteRegisters,
+    pub value: u8,
+}
 
-/// Represents a write of the specified 8-bit value to the X register.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteXRegister(pub u8);
-
-/// Represents a write of the specified 8-bit value to the Y register.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteYRegister(pub u8);
-
-/// Represents a write of the specified 8-bit value to the ProgramStatus
-/// register.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WritePSRegister(pub u8);
-
-/// Represents a write of the specified 8-bit value to the StackPointer
-/// register.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteSPRegister(pub u8);
+impl Write8bitRegister {
+    pub fn new(register: ByteRegisters, value: u8) -> Self {
+        Self { register, value }
+    }
+}
 
 // 16-bit registers
 

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -33,29 +33,29 @@ impl WriteMemory {
 
 /// Represents a write of the specified 8-bit value to the A register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteAccRegister(u8);
+pub struct WriteAccRegister(pub u8);
 
 /// Represents a write of the specified 8-bit value to the X register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteXRegister(u8);
+pub struct WriteXRegister(pub u8);
 
 /// Represents a write of the specified 8-bit value to the Y register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteYRegister(u8);
+pub struct WriteYRegister(pub u8);
 
 /// Represents a write of the specified 8-bit value to the ProgramStatus
 /// register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WritePSRegister(u8);
+pub struct WritePSRegister(pub u8);
 
 /// Represents a write of the specified 8-bit value to the StackPointer
 /// register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WriteSPRegister(u8);
+pub struct WriteSPRegister(pub u8);
 
 // 16-bit registers
 
 /// Represents a write of the specified 16-bit value to the ProgramCounter
 /// register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WritePCRegister(u16);
+pub struct WritePCRegister(pub u16);

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -1,0 +1,61 @@
+//! Stores single operations that perform state changes on the cpu these can
+//! include write operations to memory or registers and are the basic building
+//! blocks for an instruction implementation
+
+/// An Enumerable type to store each microcode operation possible on the
+/// 6502 emulator.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Microcode {
+    WriteMemory(WriteMemory),
+    WriteAccRegister(WriteAccRegister),
+    WriteXRegister(WriteXRegister),
+    WriteYRegister(WriteYRegister),
+    WritePSRegister(WritePSRegister),
+    WriteSPRegister(WriteSPRegister),
+    WritePCRegister(WritePCRegister),
+}
+
+/// Represents a write of the value to the memory location specified by the
+/// address field.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WriteMemory {
+    pub address: u16,
+    pub value: u8,
+}
+
+impl WriteMemory {
+    pub fn new(address: u16, value: u8) -> Self {
+        Self { address, value }
+    }
+}
+
+// 8-bit registers
+
+/// Represents a write of the specified 8-bit value to the A register.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WriteAccRegister(u8);
+
+/// Represents a write of the specified 8-bit value to the X register.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WriteXRegister(u8);
+
+/// Represents a write of the specified 8-bit value to the Y register.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WriteYRegister(u8);
+
+/// Represents a write of the specified 8-bit value to the ProgramStatus
+/// register.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WritePSRegister(u8);
+
+/// Represents a write of the specified 8-bit value to the StackPointer
+/// register.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WriteSPRegister(u8);
+
+// 16-bit registers
+
+/// Represents a write of the specified 16-bit value to the ProgramCounter
+/// register.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct WritePCRegister(u16);

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -2,7 +2,7 @@
 //! include write operations to memory or registers and are the basic building
 //! blocks for an instruction implementation
 
-use crate::cpu::mos6502::register::ByteRegisters;
+use crate::cpu::mos6502::register::{ByteRegisters, WordRegisters};
 
 /// An Enumerable type to store each microcode operation possible on the
 /// 6502 emulator.
@@ -10,7 +10,7 @@ use crate::cpu::mos6502::register::ByteRegisters;
 pub enum Microcode {
     WriteMemory(WriteMemory),
     Write8bitRegister(Write8bitRegister),
-    WritePCRegister(WritePCRegister),
+    Write16bitRegister(Write16bitRegister),
     IncPCRegister(IncPCRegister),
 }
 
@@ -46,10 +46,19 @@ impl Write8bitRegister {
 
 // 16-bit registers
 
-/// Represents a write of the specified 16-bit value to the ProgramCounter
-/// register.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct WritePCRegister(pub u16);
+/// Represents a write of the specified 16-bit value to one of the 16-bit
+/// registers as defined by the ByteRegisters value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Write16bitRegister {
+    pub register: WordRegisters,
+    pub value: u16,
+}
+
+impl Write16bitRegister {
+    pub fn new(register: WordRegisters, value: u16) -> Self {
+        Self { register, value }
+    }
+}
 
 /// Represents an increment of the ProgramCounter register by the value
 /// specified in the instruction.

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -11,7 +11,7 @@ pub enum Microcode {
     WriteMemory(WriteMemory),
     Write8bitRegister(Write8bitRegister),
     Write16bitRegister(Write16bitRegister),
-    IncPCRegister(IncPCRegister),
+    Inc16bitRegister(Inc16bitRegister),
 }
 
 /// Represents a write of the value to the memory location specified by the
@@ -60,7 +60,16 @@ impl Write16bitRegister {
     }
 }
 
-/// Represents an increment of the ProgramCounter register by the value
-/// specified in the instruction.
-#[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct IncPCRegister(pub u16);
+/// Represents an increment of the specified 16-bit value to one of the 16-bit
+/// registers as defined by the ByteRegisters value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Inc16bitRegister {
+    pub register: WordRegisters,
+    pub value: u16,
+}
+
+impl Inc16bitRegister {
+    pub fn new(register: WordRegisters, value: u16) -> Self {
+        Self { register, value }
+    }
+}

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -10,8 +10,11 @@ use crate::cpu::mos6502::register::{ByteRegisters, WordRegisters};
 pub enum Microcode {
     WriteMemory(WriteMemory),
     Write8bitRegister(Write8bitRegister),
+    Inc8bitRegister(Inc8bitRegister),
+    Dec8bitRegister(Dec8bitRegister),
     Write16bitRegister(Write16bitRegister),
     Inc16bitRegister(Inc16bitRegister),
+    Dec16bitRegister(Dec16bitRegister),
 }
 
 /// Represents a write of the value to the memory location specified by the
@@ -44,6 +47,34 @@ impl Write8bitRegister {
     }
 }
 
+/// Represents an increment of the specified 8-bit value to one of the 8-bit
+/// registers as defined by the ByteRegisters value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Inc8bitRegister {
+    pub register: ByteRegisters,
+    pub value: u8,
+}
+
+impl Inc8bitRegister {
+    pub fn new(register: ByteRegisters, value: u8) -> Self {
+        Self { register, value }
+    }
+}
+
+/// Represents an decrement of the specified 8-bit value to one of the 8-bit
+/// registers as defined by the ByteRegisters value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Dec8bitRegister {
+    pub register: ByteRegisters,
+    pub value: u8,
+}
+
+impl Dec8bitRegister {
+    pub fn new(register: ByteRegisters, value: u8) -> Self {
+        Self { register, value }
+    }
+}
+
 // 16-bit registers
 
 /// Represents a write of the specified 16-bit value to one of the 16-bit
@@ -69,6 +100,20 @@ pub struct Inc16bitRegister {
 }
 
 impl Inc16bitRegister {
+    pub fn new(register: WordRegisters, value: u16) -> Self {
+        Self { register, value }
+    }
+}
+
+/// Represents an decrement of the specified 16-bit value to one of the 16-bit
+/// registers as defined by the ByteRegisters value.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Dec16bitRegister {
+    pub register: WordRegisters,
+    pub value: u16,
+}
+
+impl Dec16bitRegister {
     pub fn new(register: WordRegisters, value: u16) -> Self {
         Self { register, value }
     }

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -13,6 +13,7 @@ pub enum Microcode {
     WritePSRegister(WritePSRegister),
     WriteSPRegister(WriteSPRegister),
     WritePCRegister(WritePCRegister),
+    IncPCRegister(IncPCRegister),
 }
 
 /// Represents a write of the value to the memory location specified by the
@@ -59,3 +60,8 @@ pub struct WriteSPRegister(pub u8);
 /// register.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct WritePCRegister(pub u16);
+
+/// Represents an increment of the ProgramCounter register by the value
+/// specified in the instruction.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct IncPCRegister(pub u16);

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -239,7 +239,7 @@ impl Execute<MOS6502> for microcode::Microcode {
         match self {
             Self::WriteMemory(mc) => mc.execute(cpu),
             Self::Write8bitRegister(_) => todo!(),
-            Self::WritePCRegister(mc) => mc.execute(cpu),
+            Self::Write16bitRegister(mc) => mc.execute(cpu),
             Self::IncPCRegister(mc) => mc.execute(cpu),
         }
     }
@@ -274,9 +274,9 @@ impl Execute<MOS6502> for microcode::Write8bitRegister {
     }
 }
 
-impl Execute<MOS6502> for microcode::WritePCRegister {
+impl Execute<MOS6502> for microcode::Write16bitRegister {
     fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
+        let value = self.value;
         cpu.with_pc_register(ProgramCounter::with_value(value))
     }
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -14,21 +14,15 @@ use crate::{
 mod tests;
 
 pub mod register;
-use register::{GeneralPurpose, ProcessorStatus, ProgramCounter, StackPointer};
+use register::{GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter, StackPointer};
 
 pub mod operations;
 use operations::Operation;
 
+pub mod microcode;
+
 pub trait Execute<T> {
     fn execute(self, cpu: T) -> T;
-}
-
-/// Represets each type of general purpose register available in the mos6502.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum GPRegister {
-    ACC,
-    X,
-    Y,
 }
 
 /// MOS6502 represents the 6502 CPU

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -24,7 +24,7 @@ use operations::Operation;
 pub mod microcode;
 
 pub trait Generate<T, U> {
-    fn generate<'a>(self, cpu: &'a T) -> U;
+    fn generate(self, cpu: &T) -> U;
 }
 
 pub trait Execute<T> {
@@ -49,6 +49,7 @@ impl MOS6502 {
     }
 
     /// instantiates a new MOS6502 with a provided address_map.
+    #[allow(clippy::field_reassign_with_default)]
     pub fn with_addressmap(am: AddressMap<u16>) -> Self {
         let mut cpu = Self::default();
         cpu.address_map = am;

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -14,7 +14,9 @@ use crate::{
 mod tests;
 
 pub mod register;
-use register::{GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter, StackPointer};
+use register::{
+    ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramCounter, StackPointer,
+};
 
 pub mod operations;
 use operations::Operation;
@@ -236,11 +238,7 @@ impl Execute<MOS6502> for microcode::Microcode {
     fn execute(self, cpu: MOS6502) -> MOS6502 {
         match self {
             Self::WriteMemory(mc) => mc.execute(cpu),
-            Self::WriteAccRegister(mc) => mc.execute(cpu),
-            Self::WriteXRegister(mc) => mc.execute(cpu),
-            Self::WriteYRegister(mc) => mc.execute(cpu),
-            Self::WriteSPRegister(mc) => mc.execute(cpu),
-            Self::WritePSRegister(mc) => mc.execute(cpu),
+            Self::Write8bitRegister(_) => todo!(),
             Self::WritePCRegister(mc) => mc.execute(cpu),
             Self::IncPCRegister(mc) => mc.execute(cpu),
         }
@@ -255,38 +253,24 @@ impl Execute<MOS6502> for microcode::WriteMemory {
     }
 }
 
-impl Execute<MOS6502> for microcode::WriteAccRegister {
+impl Execute<MOS6502> for microcode::Write8bitRegister {
     fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
-        cpu.with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(value))
-    }
-}
+        let register = self.register;
+        let value = self.value;
 
-impl Execute<MOS6502> for microcode::WriteXRegister {
-    fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
-        cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(value))
-    }
-}
-
-impl Execute<MOS6502> for microcode::WriteYRegister {
-    fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
-        cpu.with_gp_register(GPRegister::Y, GeneralPurpose::with_value(value))
-    }
-}
-
-impl Execute<MOS6502> for microcode::WriteSPRegister {
-    fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
-        cpu.with_sp_register(StackPointer::with_value(value))
-    }
-}
-
-impl Execute<MOS6502> for microcode::WritePSRegister {
-    fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
-        cpu.with_ps_register(ProcessorStatus::with_value(value))
+        match register {
+            ByteRegisters::ACC => {
+                cpu.with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(value))
+            }
+            ByteRegisters::X => {
+                cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(value))
+            }
+            ByteRegisters::Y => {
+                cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(value))
+            }
+            ByteRegisters::SP => cpu.with_sp_register(StackPointer::with_value(value)),
+            ByteRegisters::PS => cpu.with_ps_register(ProcessorStatus::with_value(value)),
+        }
     }
 }
 

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -197,45 +197,24 @@ impl CPU<MOS6502> for StepState<MOS6502> {
 
 impl IntoIterator for MOS6502 {
     type Item = operations::MOps;
-    type IntoIter = MicrocodeIntoIterator;
+    type IntoIter = MOS6502IntoIterator;
 
     fn into_iter(self) -> Self::IntoIter {
-        MicrocodeIntoIterator { state: self }
+        MOS6502IntoIterator::new(self)
     }
 }
 
-impl IntoIterator for StepState<MOS6502> {
-    type Item = StepState<MOS6502>;
-    type IntoIter = CPUIntoIterator;
-
-    fn into_iter(self) -> Self::IntoIter {
-        let cpu_state = self;
-
-        CPUIntoIterator { state: cpu_state }
-    }
-}
-
-pub struct CPUIntoIterator {
-    state: StepState<MOS6502>,
-}
-
-impl Iterator for CPUIntoIterator {
-    type Item = StepState<MOS6502>;
-
-    fn next(&mut self) -> Option<StepState<MOS6502>> {
-        let cpu = self.state.clone();
-        let new_state = cpu.step();
-        self.state = new_state.clone();
-
-        Some(new_state)
-    }
-}
-
-pub struct MicrocodeIntoIterator {
+pub struct MOS6502IntoIterator {
     state: MOS6502,
 }
 
-impl Iterator for MicrocodeIntoIterator {
+impl MOS6502IntoIterator {
+    fn new(state: MOS6502) -> Self {
+        MOS6502IntoIterator { state }
+    }
+}
+
+impl Iterator for MOS6502IntoIterator {
     type Item = operations::MOps;
 
     fn next(&mut self) -> Option<operations::MOps> {

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -196,13 +196,11 @@ impl CPU<MOS6502> for StepState<MOS6502> {
 }
 
 impl IntoIterator for MOS6502 {
-    type Item = StepState<MOS6502>;
-    type IntoIter = CPUIntoIterator;
+    type Item = operations::MOps;
+    type IntoIter = MicrocodeIntoIterator;
 
     fn into_iter(self) -> Self::IntoIter {
-        let cpu_state = StepState::new(1, self);
-
-        CPUIntoIterator { state: cpu_state }
+        MicrocodeIntoIterator { state: self }
     }
 }
 

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -240,7 +240,7 @@ impl Execute<MOS6502> for microcode::Microcode {
             Self::WriteMemory(mc) => mc.execute(cpu),
             Self::Write8bitRegister(_) => todo!(),
             Self::Write16bitRegister(mc) => mc.execute(cpu),
-            Self::IncPCRegister(mc) => mc.execute(cpu),
+            Self::Inc16bitRegister(mc) => mc.execute(cpu),
         }
     }
 }
@@ -276,15 +276,13 @@ impl Execute<MOS6502> for microcode::Write8bitRegister {
 
 impl Execute<MOS6502> for microcode::Write16bitRegister {
     fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.value;
-        cpu.with_pc_register(ProgramCounter::with_value(value))
+        cpu.with_pc_register(ProgramCounter::with_value(self.value))
     }
 }
 
-impl Execute<MOS6502> for microcode::IncPCRegister {
+impl Execute<MOS6502> for microcode::Inc16bitRegister {
     fn execute(self, cpu: MOS6502) -> MOS6502 {
-        let value = self.0;
-        let pc = cpu.pc.read() + value;
+        let pc = cpu.pc.read() + self.value;
         cpu.with_pc_register(ProgramCounter::with_value(pc))
     }
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -21,6 +21,10 @@ use operations::Operation;
 
 pub mod microcode;
 
+pub trait Generate<T, U> {
+    fn generate<'a>(self, cpu: &'a T) -> U;
+}
+
 pub trait Execute<T> {
     fn execute(self, cpu: T) -> T;
 }

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -165,7 +165,7 @@ impl CPU<MOS6502> for MOS6502 {
         let state = self
             .clone()
             .into_iter()
-            .map(|mop| Into::<Vec<Vec<microcode::Microcode>>>::into(mop))
+            .map(Into::<Vec<Vec<microcode::Microcode>>>::into)
             .flatten() // flatten instructions to cycles
             .take(cycles)
             .flatten()

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -229,3 +229,78 @@ impl Iterator for CPUIntoIterator {
         Some(new_state)
     }
 }
+
+// microcode execution
+
+impl Execute<MOS6502> for microcode::Microcode {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        match self {
+            Self::WriteMemory(mc) => mc.execute(cpu),
+            Self::WriteAccRegister(mc) => mc.execute(cpu),
+            Self::WriteXRegister(mc) => mc.execute(cpu),
+            Self::WriteYRegister(mc) => mc.execute(cpu),
+            Self::WriteSPRegister(mc) => mc.execute(cpu),
+            Self::WritePSRegister(mc) => mc.execute(cpu),
+            Self::WritePCRegister(mc) => mc.execute(cpu),
+            Self::IncPCRegister(mc) => mc.execute(cpu),
+        }
+    }
+}
+
+impl Execute<MOS6502> for microcode::WriteMemory {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let mut cpu = cpu;
+        cpu.address_map.write(self.address, self.value).unwrap();
+        cpu
+    }
+}
+
+impl Execute<MOS6502> for microcode::WriteAccRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        cpu.with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(value))
+    }
+}
+
+impl Execute<MOS6502> for microcode::WriteXRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(value))
+    }
+}
+
+impl Execute<MOS6502> for microcode::WriteYRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        cpu.with_gp_register(GPRegister::Y, GeneralPurpose::with_value(value))
+    }
+}
+
+impl Execute<MOS6502> for microcode::WriteSPRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        cpu.with_sp_register(StackPointer::with_value(value))
+    }
+}
+
+impl Execute<MOS6502> for microcode::WritePSRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        cpu.with_ps_register(ProcessorStatus::with_value(value))
+    }
+}
+
+impl Execute<MOS6502> for microcode::WritePCRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        cpu.with_pc_register(ProgramCounter::with_value(value))
+    }
+}
+
+impl Execute<MOS6502> for microcode::IncPCRegister {
+    fn execute(self, cpu: MOS6502) -> MOS6502 {
+        let value = self.0;
+        let pc = cpu.pc.read() + value;
+        cpu.with_pc_register(ProgramCounter::with_value(pc))
+    }
+}

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -11,12 +11,6 @@ pub struct Accumulator;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Implied;
 
-impl Cyclable for Implied {
-    fn cycles(&self) -> usize {
-        0
-    }
-}
-
 impl Offset for Implied {
     fn offset(&self) -> usize {
         0
@@ -44,11 +38,6 @@ impl<'a> Parser<'a, &'a [u8], Immediate> for Immediate {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Absolute(pub u16);
 
-impl Cyclable for Absolute {
-    fn cycles(&self) -> usize {
-        2
-    }
-}
 impl Offset for Absolute {
     fn offset(&self) -> usize {
         2
@@ -72,11 +61,6 @@ pub struct Relative(i8);
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Indirect(pub u16);
 
-impl Cyclable for Indirect {
-    fn cycles(&self) -> usize {
-        4
-    }
-}
 impl Offset for Indirect {
     fn offset(&self) -> usize {
         2

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -26,11 +26,6 @@ pub struct LDY;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct STA;
 
-impl Cyclable for STA {
-    fn cycles(&self) -> usize {
-        2
-    }
-}
 impl Offset for STA {}
 
 impl<'a> Parser<'a, &'a [u8], STA> for STA {
@@ -171,12 +166,6 @@ pub struct PLP;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct JMP;
 
-impl Cyclable for JMP {
-    fn cycles(&self) -> usize {
-        1
-    }
-}
-
 impl Offset for JMP {}
 
 impl<'a> Parser<'a, &'a [u8], JMP> for JMP {
@@ -229,12 +218,6 @@ pub struct BRK;
 /// mode and functions as a "No Instruction".
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct NOP;
-
-impl Cyclable for NOP {
-    fn cycles(&self) -> usize {
-        2
-    }
-}
 
 impl Offset for NOP {}
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -401,7 +401,7 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Absolu
             self.cycles(),
             vec![Microcode::Write16bitRegister(Write16bitRegister::new(
                 WordRegisters::PC,
-                addr,
+                addr - self.offset() as u16,
             ))],
         )
     }
@@ -448,7 +448,7 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Indire
             self.cycles(),
             vec![Microcode::Write16bitRegister(Write16bitRegister::new(
                 WordRegisters::PC,
-                addr,
+                addr - self.offset() as u16,
             ))],
         )
     }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -15,7 +15,8 @@ pub mod mnemonic;
 mod tests;
 
 /// MOps functions as a concrete wrapper around a microcode operation with
-/// metadata around sizing and cycles.
+/// metadata around sizing and cycles. This trait does NOT represent a cycle
+/// but rather the microcode equivalent of a CPU instruction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MOps {
     offset: usize,
@@ -66,15 +67,15 @@ impl From<MOps> for Vec<Vec<Microcode>> {
 pub struct Operation {
     offset: usize,
     cycles: usize,
-    mc_generator: Box<dyn Fn(&MOS6502) -> MOps>,
+    generator: Box<dyn Fn(&MOS6502) -> MOps>,
 }
 
 impl Operation {
-    pub fn new(offset: usize, cycles: usize, mc_generator: Box<dyn Fn(&MOS6502) -> MOps>) -> Self {
+    pub fn new(offset: usize, cycles: usize, generator: Box<dyn Fn(&MOS6502) -> MOps>) -> Self {
         Self {
             offset,
             cycles,
-            mc_generator,
+            generator,
         }
     }
 }
@@ -93,7 +94,7 @@ impl Offset for Operation {
 
 impl Generate<MOS6502, MOps> for Operation {
     fn generate(self, cpu: &MOS6502) -> MOps {
-        (self.mc_generator)(cpu)
+        (self.generator)(cpu)
     }
 }
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -1,7 +1,7 @@
 extern crate parcel;
 use crate::address_map::Addressable;
 use crate::cpu::{
-    mos6502::{microcode::*, register::*, Execute, GPRegister, Generate, MOS6502},
+    mos6502::{microcode::*, register::*, Execute, Generate, MOS6502},
     register::Register,
     Cyclable, Offset,
 };
@@ -231,7 +231,10 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Immedi
         MOps::new(
             self.offset(),
             self.cycles(),
-            vec![Microcode::WriteAccRegister(WriteAccRegister(value))],
+            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+                ByteRegisters::ACC,
+                value,
+            ))],
         )
     }
 }
@@ -271,7 +274,10 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolu
         MOps::new(
             self.offset(),
             self.cycles(),
-            vec![Microcode::WriteAccRegister(WriteAccRegister(val))],
+            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+                ByteRegisters::ACC,
+                val,
+            ))],
         )
     }
 }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -51,7 +51,10 @@ impl From<MOps> for Vec<Vec<Microcode>> {
         let offset = src.offset() as u16;
         let mut mcs = vec![vec![]; cycles - 1];
         let mut microcode = src.microcode;
-        microcode.push(Microcode::IncPCRegister(IncPCRegister(offset)));
+        microcode.push(Microcode::Inc16bitRegister(Inc16bitRegister::new(
+            WordRegisters::PC,
+            offset,
+        )));
 
         mcs.push(microcode);
         mcs

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -396,7 +396,10 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Absolu
         MOps::new(
             self.offset(),
             self.cycles(),
-            vec![Microcode::WritePCRegister(WritePCRegister(addr))],
+            vec![Microcode::Write16bitRegister(Write16bitRegister::new(
+                WordRegisters::PC,
+                addr,
+            ))],
         )
     }
 }
@@ -440,7 +443,10 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Indire
         MOps::new(
             self.offset(),
             self.cycles(),
-            vec![Microcode::WritePCRegister(WritePCRegister(addr))],
+            vec![Microcode::Write16bitRegister(Write16bitRegister::new(
+                WordRegisters::PC,
+                addr,
+            ))],
         )
     }
 }

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -105,7 +105,7 @@ impl Execute<MOS6502> for Operation {
 }
 
 impl Generate<MOS6502, MOps> for Operation {
-    fn generate<'a>(self, cpu: &'a MOS6502) -> MOps {
+    fn generate(self, cpu: &MOS6502) -> MOps {
         (self.mc_generator)(cpu)
     }
 }
@@ -229,7 +229,7 @@ impl Execute<MOS6502> for Instruction<mnemonic::LDA, address_mode::Immediate> {
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Immediate> {
-    fn generate<'a>(self, _: &'a MOS6502) -> MOps {
+    fn generate(self, _: &MOS6502) -> MOps {
         let address_mode::Immediate(value) = self.address_mode;
         MOps::new(
             self.offset(),
@@ -271,7 +271,7 @@ impl Execute<MOS6502> for Instruction<mnemonic::LDA, address_mode::Absolute> {
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolute> {
-    fn generate<'a>(self, cpu: &'a MOS6502) -> MOps {
+    fn generate(self, cpu: &MOS6502) -> MOps {
         let address_mode::Absolute(addr) = self.address_mode;
         let val = cpu.address_map.read(addr);
         MOps::new(
@@ -319,7 +319,7 @@ impl Execute<MOS6502> for Instruction<mnemonic::STA, address_mode::Absolute> {
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::Absolute> {
-    fn generate<'a>(self, cpu: &'a MOS6502) -> MOps {
+    fn generate(self, cpu: &MOS6502) -> MOps {
         let address_mode::Absolute(addr) = self.address_mode;
         let acc_val = cpu.acc.read();
         MOps::new(
@@ -359,7 +359,7 @@ impl Execute<MOS6502> for Instruction<mnemonic::NOP, address_mode::Implied> {
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::NOP, address_mode::Implied> {
-    fn generate<'a>(self, _: &'a MOS6502) -> MOps {
+    fn generate(self, _: &MOS6502) -> MOps {
         MOps::new(self.offset(), self.cycles(), vec![])
     }
 }
@@ -394,7 +394,7 @@ impl Execute<MOS6502> for Instruction<mnemonic::JMP, address_mode::Absolute> {
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Absolute> {
-    fn generate<'a>(self, _: &'a MOS6502) -> MOps {
+    fn generate(self, _: &MOS6502) -> MOps {
         let address_mode::Absolute(addr) = self.address_mode;
         MOps::new(
             self.offset(),
@@ -438,7 +438,7 @@ impl Execute<MOS6502> for Instruction<mnemonic::JMP, address_mode::Indirect> {
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Indirect> {
-    fn generate<'a>(self, cpu: &'a MOS6502) -> MOps {
+    fn generate(self, cpu: &MOS6502) -> MOps {
         let address_mode::Indirect(indirect_addr) = self.address_mode;
         let lsb = cpu.address_map.read(indirect_addr);
         let msb = cpu.address_map.read(indirect_addr + 1);

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -150,8 +150,8 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Instruction<M, A>
 where
-    M: Cyclable + Offset + Copy + Debug + PartialEq,
-    A: Cyclable + Offset + Copy + Debug + PartialEq,
+    M: Offset + Copy + Debug + PartialEq,
+    A: Offset + Copy + Debug + PartialEq,
 {
     mnemonic: M,
     address_mode: A,
@@ -159,8 +159,8 @@ where
 
 impl<M, A> Instruction<M, A>
 where
-    M: Cyclable + Offset + Copy + Debug + PartialEq,
-    A: Cyclable + Offset + Copy + Debug + PartialEq,
+    M: Offset + Copy + Debug + PartialEq,
+    A: Offset + Copy + Debug + PartialEq,
 {
     pub fn new(mnemonic: M, address_mode: A) -> Self {
         Instruction {
@@ -170,20 +170,10 @@ where
     }
 }
 
-impl<M, A> Cyclable for Instruction<M, A>
-where
-    M: Cyclable + Offset + Copy + Debug + PartialEq,
-    A: Cyclable + Offset + Copy + Debug + PartialEq,
-{
-    fn cycles(&self) -> usize {
-        self.mnemonic.cycles() + self.address_mode.cycles()
-    }
-}
-
 impl<M, A> Offset for Instruction<M, A>
 where
-    M: Cyclable + Offset + Copy + Debug + PartialEq,
-    A: Cyclable + Offset + Copy + Debug + PartialEq,
+    M: Offset + Copy + Debug + PartialEq,
+    A: Offset + Copy + Debug + PartialEq,
 {
     fn offset(&self) -> usize {
         self.mnemonic.offset() + self.address_mode.offset()
@@ -192,9 +182,9 @@ where
 
 impl<M, A> Into<Operation> for Instruction<M, A>
 where
-    M: Cyclable + Offset + Copy + Debug + PartialEq + 'static,
-    A: Cyclable + Offset + Copy + Debug + PartialEq + 'static,
-    Self: Execute<MOS6502> + Generate<MOS6502, MOps> + 'static,
+    M: Offset + Copy + Debug + PartialEq + 'static,
+    A: Offset + Copy + Debug + PartialEq + 'static,
+    Self: Execute<MOS6502> + Generate<MOS6502, MOps> + Cyclable + 'static,
 {
     fn into(self) -> Operation {
         Operation::new(
@@ -207,6 +197,12 @@ where
 }
 
 /// LDA
+
+impl Cyclable for Instruction<mnemonic::LDA, address_mode::Immediate> {
+    fn cycles(&self) -> usize {
+        2
+    }
+}
 
 impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::LDA, address_mode::Immediate>>
     for Instruction<mnemonic::LDA, address_mode::Immediate>
@@ -237,6 +233,12 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Immedi
             self.cycles(),
             vec![Microcode::WriteAccRegister(WriteAccRegister(value))],
         )
+    }
+}
+
+impl Cyclable for Instruction<mnemonic::LDA, address_mode::Absolute> {
+    fn cycles(&self) -> usize {
+        4
     }
 }
 
@@ -276,6 +278,12 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::LDA, address_mode::Absolu
 
 /// STA
 
+impl Cyclable for Instruction<mnemonic::STA, address_mode::Absolute> {
+    fn cycles(&self) -> usize {
+        4
+    }
+}
+
 impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::STA, address_mode::Absolute>>
     for Instruction<mnemonic::STA, address_mode::Absolute>
 {
@@ -313,7 +321,13 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::Absolu
     }
 }
 
-/// NOP
+// NOP
+
+impl Cyclable for Instruction<mnemonic::NOP, address_mode::Implied> {
+    fn cycles(&self) -> usize {
+        2
+    }
+}
 
 impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::NOP, address_mode::Implied>>
     for Instruction<mnemonic::NOP, address_mode::Implied>
@@ -342,6 +356,12 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::NOP, address_mode::Implie
 }
 
 // JMP
+
+impl Cyclable for Instruction<mnemonic::JMP, address_mode::Absolute> {
+    fn cycles(&self) -> usize {
+        3
+    }
+}
 
 impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::JMP, address_mode::Absolute>>
     for Instruction<mnemonic::JMP, address_mode::Absolute>
@@ -372,6 +392,12 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Absolu
             self.cycles(),
             vec![Microcode::WritePCRegister(WritePCRegister(addr))],
         )
+    }
+}
+
+impl Cyclable for Instruction<mnemonic::JMP, address_mode::Indirect> {
+    fn cycles(&self) -> usize {
+        5
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -116,3 +116,65 @@ fn should_generate_absolute_address_mode_sta_machine_code() {
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
 }
+
+#[test]
+fn should_generate_absolute_address_mode_jmp_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::JMP, address_mode::Absolute(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            3,
+            3,
+            vec![Microcode::WritePCRegister(WritePCRegister(0x0100))]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![
+                Microcode::WritePCRegister(WritePCRegister(0x0100)),
+                Microcode::IncPCRegister(IncPCRegister(3))
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_indirect_address_mode_jmp_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::JMP, address_mode::Indirect(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            3,
+            5,
+            vec![Microcode::WritePCRegister(WritePCRegister(0x0000))]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WritePCRegister(WritePCRegister(0x0000)),
+                Microcode::IncPCRegister(IncPCRegister(3))
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -4,16 +4,10 @@ use crate::cpu::mos6502::{
     Generate, MOS6502,
 };
 
-macro_rules! inst_to_operation {
-    ($mnemonic:expr, $addrmode:expr) => {
-        Instruction::new($mnemonic, $addrmode).into()
-    };
-}
-
 #[test]
 fn should_generate_implied_address_mode_nop_machine_code() {
     let cpu = MOS6502::default();
-    let op: Operation = inst_to_operation!(mnemonic::NOP, address_mode::Implied);
+    let op: Operation = Instruction::new(mnemonic::NOP, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     // check Mops value is correct
@@ -22,6 +16,35 @@ fn should_generate_implied_address_mode_nop_machine_code() {
     // validate mops -> vector looks correct
     assert_eq!(
         vec![vec![], vec![Microcode::IncPCRegister(IncPCRegister(1))]],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_immediate_address_mode_lda_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDA, address_mode::Immediate(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            2,
+            2,
+            vec![Microcode::WriteAccRegister(WriteAccRegister(0xff))]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![
+                Microcode::WriteAccRegister(WriteAccRegister(0xff)),
+                Microcode::IncPCRegister(IncPCRegister(2))
+            ]
+        ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -4,6 +4,8 @@ use crate::cpu::mos6502::{
     Generate, MOS6502,
 };
 
+// NOP
+
 #[test]
 fn should_generate_implied_address_mode_nop_machine_code() {
     let cpu = MOS6502::default();
@@ -19,6 +21,8 @@ fn should_generate_implied_address_mode_nop_machine_code() {
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
 }
+
+// LDA
 
 #[test]
 fn should_generate_immediate_address_mode_lda_machine_code() {
@@ -43,6 +47,70 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
             vec![
                 Microcode::WriteAccRegister(WriteAccRegister(0xff)),
                 Microcode::IncPCRegister(IncPCRegister(2))
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
+fn should_generate_absolute_address_mode_lda_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDA, address_mode::Absolute(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![Microcode::WriteAccRegister(WriteAccRegister(0x00))]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WriteAccRegister(WriteAccRegister(0x00)),
+                Microcode::IncPCRegister(IncPCRegister(3))
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+// STA
+
+#[test]
+fn should_generate_absolute_address_mode_sta_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::STA, address_mode::Absolute(0x0100)).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            3,
+            4,
+            vec![Microcode::WriteMemory(WriteMemory::new(0x0100, 0x00))]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![],
+            vec![
+                Microcode::WriteMemory(WriteMemory::new(0x0100, 0x00)),
+                Microcode::IncPCRegister(IncPCRegister(3))
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -18,7 +18,13 @@ fn should_generate_implied_address_mode_nop_machine_code() {
 
     // validate mops -> vector looks correct
     assert_eq!(
-        vec![vec![], vec![Microcode::IncPCRegister(IncPCRegister(1))]],
+        vec![
+            vec![],
+            vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
+                WordRegisters::PC,
+                1
+            ))]
+        ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
 }
@@ -50,7 +56,7 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
             vec![],
             vec![
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff)),
-                Microcode::IncPCRegister(IncPCRegister(2))
+                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -84,7 +90,7 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
             vec![],
             vec![
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
-                Microcode::IncPCRegister(IncPCRegister(3))
+                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -117,7 +123,7 @@ fn should_generate_absolute_address_mode_sta_machine_code() {
             vec![],
             vec![
                 Microcode::WriteMemory(WriteMemory::new(0x0100, 0x00)),
-                Microcode::IncPCRegister(IncPCRegister(3))
+                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -150,7 +156,7 @@ fn should_generate_absolute_address_mode_jmp_machine_code() {
             vec![],
             vec![
                 Microcode::Write16bitRegister(Write16bitRegister::new(WordRegisters::PC, 0x0100)),
-                Microcode::IncPCRegister(IncPCRegister(3))
+                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -185,7 +191,7 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
             vec![],
             vec![
                 Microcode::Write16bitRegister(Write16bitRegister::new(WordRegisters::PC, 0x0000)),
-                Microcode::IncPCRegister(IncPCRegister(3))
+                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1,7 +1,7 @@
 use crate::cpu::mos6502::{
     microcode::*,
     operations::{address_mode, mnemonic, Instruction, MOps, Operation},
-    register::ByteRegisters,
+    register::{ByteRegisters, WordRegisters},
     Generate, MOS6502,
 };
 
@@ -135,7 +135,10 @@ fn should_generate_absolute_address_mode_jmp_machine_code() {
         MOps::new(
             3,
             3,
-            vec![Microcode::WritePCRegister(WritePCRegister(0x0100))]
+            vec![Microcode::Write16bitRegister(Write16bitRegister::new(
+                WordRegisters::PC,
+                0x0100
+            ))]
         ),
         mc
     );
@@ -146,7 +149,7 @@ fn should_generate_absolute_address_mode_jmp_machine_code() {
             vec![],
             vec![],
             vec![
-                Microcode::WritePCRegister(WritePCRegister(0x0100)),
+                Microcode::Write16bitRegister(Write16bitRegister::new(WordRegisters::PC, 0x0100)),
                 Microcode::IncPCRegister(IncPCRegister(3))
             ]
         ],
@@ -165,7 +168,10 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
         MOps::new(
             3,
             5,
-            vec![Microcode::WritePCRegister(WritePCRegister(0x0000))]
+            vec![Microcode::Write16bitRegister(Write16bitRegister::new(
+                WordRegisters::PC,
+                0x0000
+            )),]
         ),
         mc
     );
@@ -178,7 +184,7 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
             vec![],
             vec![],
             vec![
-                Microcode::WritePCRegister(WritePCRegister(0x0000)),
+                Microcode::Write16bitRegister(Write16bitRegister::new(WordRegisters::PC, 0x0000)),
                 Microcode::IncPCRegister(IncPCRegister(3))
             ]
         ],

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1,0 +1,27 @@
+use crate::cpu::mos6502::{
+    microcode::*,
+    operations::{address_mode, mnemonic, Instruction, MOps, Operation},
+    Generate, MOS6502,
+};
+
+macro_rules! inst_to_operation {
+    ($mnemonic:expr, $addrmode:expr) => {
+        Instruction::new($mnemonic, $addrmode).into()
+    };
+}
+
+#[test]
+fn should_generate_implied_address_mode_nop_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = inst_to_operation!(mnemonic::NOP, address_mode::Implied);
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(MOps::new(1, 2, vec![]), mc);
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![vec![], vec![Microcode::IncPCRegister(IncPCRegister(1))]],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -1,6 +1,7 @@
 use crate::cpu::mos6502::{
     microcode::*,
     operations::{address_mode, mnemonic, Instruction, MOps, Operation},
+    register::ByteRegisters,
     Generate, MOS6502,
 };
 
@@ -35,7 +36,10 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
         MOps::new(
             2,
             2,
-            vec![Microcode::WriteAccRegister(WriteAccRegister(0xff))]
+            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+                ByteRegisters::ACC,
+                0xff
+            ))]
         ),
         mc
     );
@@ -45,7 +49,7 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
         vec![
             vec![],
             vec![
-                Microcode::WriteAccRegister(WriteAccRegister(0xff)),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff)),
                 Microcode::IncPCRegister(IncPCRegister(2))
             ]
         ],
@@ -64,7 +68,10 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
         MOps::new(
             3,
             4,
-            vec![Microcode::WriteAccRegister(WriteAccRegister(0x00))]
+            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+                ByteRegisters::ACC,
+                0x00
+            ))]
         ),
         mc
     );
@@ -76,7 +83,7 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
-                Microcode::WriteAccRegister(WriteAccRegister(0x00)),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
                 Microcode::IncPCRegister(IncPCRegister(3))
             ]
         ],

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -1,6 +1,9 @@
 extern crate parcel;
 use std::convert::TryFrom;
 
+#[cfg(test)]
+mod code_generation;
+
 macro_rules! gen_op_parse_assertion {
     ($bytecode:expr) => {
         assert!($crate::cpu::mos6502::operations::Operation::try_from($bytecode).is_ok())

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -2,7 +2,8 @@ use crate::cpu::register::Register;
 
 /// Represets each type of register available in the mos6502.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum ByteRegisters {
+pub enum Registers {
+    PC,
     ACC,
     X,
     Y,
@@ -10,10 +11,15 @@ pub enum ByteRegisters {
     SP,
 }
 
-/// Represets each type of register available in the mos6502.
+/// Represets each type of word-sized register available in the mos6502.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum Registers {
+pub enum WordRegisters {
     PC,
+}
+
+/// Represets each type of byte-sized register available in the mos6502.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ByteRegisters {
     ACC,
     X,
     Y,

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -1,5 +1,24 @@
 use crate::cpu::register::Register;
 
+/// Represets each type of register available in the mos6502.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Registers {
+    PC,
+    ACC,
+    X,
+    Y,
+    PS,
+    SP,
+}
+
+/// Represets each type of general purpose register available in the mos6502.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GPRegister {
+    ACC,
+    X,
+    Y,
+}
+
 #[derive(Debug, Default, PartialEq, Clone, Copy)]
 pub struct GeneralPurpose {
     inner: u8,

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -2,6 +2,16 @@ use crate::cpu::register::Register;
 
 /// Represets each type of register available in the mos6502.
 #[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ByteRegisters {
+    ACC,
+    X,
+    Y,
+    PS,
+    SP,
+}
+
+/// Represets each type of register available in the mos6502.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Registers {
     PC,
     ACC,

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -68,7 +68,7 @@ fn should_cycle_on_lda_absolute_operation() {
 
     let state = Into::<StepState<MOS6502>>::into(cpu)
         .into_iter()
-        .nth(2)
+        .nth(3)
         .unwrap();
 
     assert_eq!(0, state.remaining);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -3,9 +3,7 @@ use crate::address_map::{
     Addressable,
 };
 use crate::cpu::{
-    mos6502::{
-        microcode, operations, register, Execute, GPRegister, MicrocodeIntoIterator, MOS6502,
-    },
+    mos6502::{microcode, register, Execute, GPRegister, MicrocodeIntoIterator, MOS6502},
     register::Register,
     StepState,
 };
@@ -59,17 +57,17 @@ fn should_cycle_on_lda_immediate_operation() {
 
 #[test]
 fn should_cycle_on_lda_immediate_mops() {
-    let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff]);
+    let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff, 0xa9, 0x0f]);
     let state = MicrocodeIntoIterator { state: cpu.clone() }
         .into_iter()
-        .take(1)
+        .take(2)
         .map(|mop| Into::<Vec<Vec<microcode::Microcode>>>::into(mop))
         .flatten()
         .flatten()
         .fold(cpu, |c, mc| mc.execute(c));
 
-    assert_eq!(0x6002, state.pc.read());
-    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0x6004, state.pc.read());
+    assert_eq!(0x0f, state.acc.read());
 }
 
 #[test]

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -3,10 +3,21 @@ use crate::address_map::{
     Addressable,
 };
 use crate::cpu::{
-    mos6502::{microcode, register, Execute, GPRegister, MicrocodeIntoIterator, MOS6502},
+    mos6502::{microcode, register, Execute, GPRegister, MOS6502},
     register::Register,
-    StepState,
 };
+
+macro_rules! run_cpu_cycles {
+    ($cpu:expr, $cycles:literal) => {
+        $cpu.clone()
+            .into_iter()
+            .map(|mop| Into::<Vec<Vec<microcode::Microcode>>>::into(mop))
+            .flatten() // flatten instructions to cycles
+            .take($cycles)
+            .flatten()
+            .fold($cpu, |c, mc| mc.execute(c));
+    };
+}
 
 fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
     let (start_addr, stop_addr) = (0x6000, 0x7000);
@@ -29,43 +40,19 @@ fn generate_test_cpu_with_instructions(opcodes: Vec<u8>) -> MOS6502 {
 #[test]
 fn should_cycle_on_nop_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![]);
-    let states: Vec<StepState<MOS6502>> = Into::<StepState<MOS6502>>::into(cpu)
-        .into_iter()
-        .take(3)
-        .collect();
+    let state = run_cpu_cycles!(cpu, 3);
+    assert_eq!(0x6001, state.pc.read());
 
-    assert_eq!(1, states.first().unwrap().remaining);
-    assert_eq!(0x6001, states.first().unwrap().cpu.pc.read());
-
-    // run 2 more cycles and validate next nop is picked up
-    assert_eq!(1, states.last().unwrap().remaining);
-    assert_eq!(0x6002, states.last().unwrap().cpu.pc.read());
+    // take 2 more cycles to validate ea has incremented again.
+    let next_state = run_cpu_cycles!(state, 2);
+    assert_eq!(0x6002, next_state.pc.read());
 }
 
 #[test]
 fn should_cycle_on_lda_immediate_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff]);
-    let state = Into::<StepState<MOS6502>>::into(cpu)
-        .into_iter()
-        .nth(0)
-        .unwrap();
-
-    assert_eq!(1, state.remaining);
-    assert_eq!(0x6002, state.cpu.pc.read());
-    assert_eq!(0xff, state.cpu.acc.read());
-}
-
-#[test]
-fn should_cycle_on_lda_immediate_mops() {
     let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff, 0xa9, 0x0f]);
-    let state = MicrocodeIntoIterator { state: cpu.clone() }
-        .into_iter()
-        .take(2)
-        .map(|mop| Into::<Vec<Vec<microcode::Microcode>>>::into(mop))
-        .flatten()
-        .flatten()
-        .fold(cpu, |c, mc| mc.execute(c));
 
+    let state = run_cpu_cycles!(cpu, 4);
     assert_eq!(0x6004, state.pc.read());
     assert_eq!(0x0f, state.acc.read());
 }
@@ -81,16 +68,11 @@ fn should_cycle_on_lda_absolute_operation() {
         )
         .unwrap();
 
-    let state = Into::<StepState<MOS6502>>::into(cpu)
-        .into_iter()
-        .nth(3)
-        .unwrap();
-
-    assert_eq!(0, state.remaining);
+    let state = run_cpu_cycles!(cpu, 4);
 
     // val in mem should be null
-    assert_eq!(0x00, state.cpu.acc.read());
-    assert_eq!(0x00, state.cpu.address_map.read(0x0200));
+    assert_eq!(0x00, state.acc.read());
+    assert_eq!(0x00, state.address_map.read(0x0200));
 }
 
 #[test]
@@ -104,36 +86,24 @@ fn should_cycle_on_sta_absolute_operation() {
         )
         .unwrap();
 
-    let state = Into::<StepState<MOS6502>>::into(cpu)
-        .into_iter()
-        .nth(3)
-        .unwrap();
+    let state = run_cpu_cycles!(cpu, 4);
 
-    assert_eq!(0, state.remaining);
-    assert_eq!(0xff, state.cpu.acc.read());
-    assert_eq!(0xff, state.cpu.address_map.read(0x0200));
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.address_map.read(0x0200));
 }
 
 #[test]
 fn should_cycle_on_jmp_absolute_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x4c, 0x50, 0x60]);
-    let state = Into::<StepState<MOS6502>>::into(cpu)
-        .into_iter()
-        .nth(2)
-        .unwrap();
 
-    assert_eq!(0, state.remaining);
-    assert_eq!(0x6050, state.cpu.pc.read());
+    let state = run_cpu_cycles!(cpu, 3);
+    assert_eq!(0x6050, state.pc.read());
 }
 
 #[test]
 fn should_cycle_on_jmp_indirect_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x6c, 0x50, 0x60]);
-    let state = Into::<StepState<MOS6502>>::into(cpu)
-        .into_iter()
-        .nth(4)
-        .unwrap();
+    let state = run_cpu_cycles!(cpu, 5);
 
-    assert_eq!(0, state.remaining);
-    assert_eq!(0xeaea, state.cpu.pc.read());
+    assert_eq!(0xeaea, state.pc.read());
 }


### PR DESCRIPTION
# Introduction
This PR introduces state change between instructions via a microcode analog. This is accomplished by introducing a new trait `Generate` that emits microcode instructions for the CPU. These actions provide significantly smaller records to store when storing state change over time than if a copy of the CPU had to be collected and stored at each cycle in the realm of < 20 bytes per cycle rather than 64kb.

In addition to shrinking memory footprint, This simplifies the process of implementing instructions as they make no state changes but instead emit a subset of change operations for the CPU. Examples include, writing to a location in memory, writing to a register and incrementing/decrementing a register.

This also moves CPU way from `step` to a `run` method that takes the number of cycles to run as an argument.

## Example

Operating directly with iterators:

```rust
#[test]
fn should_cycle_on_lda_immediate_mops() {
    let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff, 0xa9, 0x0f]);
    let state = cpu.clone()
        .into_iter()
        .map(|mop| Into::<Vec<Vec<microcode::Microcode>>>::into(mop))
        .flatten() // flatten mops down to a vector of cycles
        .take(4)   // take 4 cycles
        .flatten() // flatten the cycles to an iteratover over microcode instructions
        .fold(cpu, |c, mc| mc.execute(c));

    assert_eq!(0x6004, state.pc.read());
    assert_eq!(0x0f, state.acc.read());
}
```

Operating via the CPU trait's run method

```rust
#[test]
fn should_cycle_on_lda_immediate_operation() {
    let cpu = generate_test_cpu_with_instructions(vec![0xa9, 0xff, 0xa9, 0x0f]);

    let state = cpu.run(4).unwrap();
    assert_eq!(0x6004, state.pc.read());
    assert_eq!(0x0f, state.acc.read());
}
```

# Linked Issues
resolves #35
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
