### PR TITLE
Implement LDA zeropage for the MOS6502

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -53,7 +53,16 @@ impl<'a> Parser<'a, &'a [u8], Absolute> for Absolute {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ZeroPage(u8);
+pub struct ZeroPage(pub u8);
+
+impl Cyclable for ZeroPage {}
+impl Offset for ZeroPage {}
+
+impl<'a> Parser<'a, &'a [u8], ZeroPage> for ZeroPage {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], ZeroPage> {
+        any_byte().map(ZeroPage).parse(input)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Relative(i8);

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -52,7 +52,7 @@ impl<'a> Parser<'a, &'a [u8], Absolute> for Absolute {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ZeroPage(pub u8);
 
 impl Cyclable for ZeroPage {}

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -11,9 +11,13 @@ impl Offset for LDA {}
 
 impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
     fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], LDA> {
-        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0xa9)])
-            .map(|_| LDA)
-            .parse(input)
+        parcel::one_of(vec![
+            parcel::parsers::byte::expect_byte(0xa9),
+            parcel::parsers::byte::expect_byte(0xa5),
+            parcel::parsers::byte::expect_byte(0xad),
+        ])
+        .map(|_| LDA)
+        .parse(input)
     }
 }
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -127,6 +127,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
         parcel::one_of(vec![
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::LDA, address_mode::Immediate::default()),
+            inst_to_operation!(mnemonic::LDA, address_mode::ZeroPage::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::JMP, address_mode::Absolute::default()),

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -65,6 +65,39 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
 }
 
 #[test]
+fn should_generate_zeropage_address_mode_lda_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::LDA, address_mode::ZeroPage(0xff)).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            2,
+            3,
+            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
+                ByteRegisters::ACC,
+                0x00 // memory defaults to null
+            ))]
+        ),
+        mc
+    );
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![],
+            vec![
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
+                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
+            ]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
+#[test]
 fn should_generate_absolute_address_mode_lda_machine_code() {
     let cpu = MOS6502::default();
     let op: Operation = Instruction::new(mnemonic::LDA, address_mode::Absolute(0x0100)).into();

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -23,6 +23,12 @@ fn should_parse_immediate_address_mode_lda_instruction() {
 }
 
 #[test]
+fn should_parse_zeropage_address_mode_lda_instruction() {
+    let bytecode = [0xa5, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_sta_instruction() {
     let bytecode = [0x8d, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -47,6 +47,15 @@ fn should_cycle_on_lda_immediate_operation() {
 }
 
 #[test]
+fn should_cycle_on_lda_zeropage_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xa5, 0xff]);
+
+    let state = cpu.run(3).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0x00, state.acc.read());
+}
+
+#[test]
 fn should_cycle_on_lda_absolute_operation() {
     let (ram_start, ram_end) = (0x0200, 0x5fff);
     let cpu = generate_test_cpu_with_instructions(vec![0xad, 0x00, 0x02])


### PR DESCRIPTION
# Introduction
This PR implements the lda zeropage instruction for the mos6502 cpu.
# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
