### PR TITLE
Implement LDA zeropage indexed with X instruction for the MOS6502 cpu

### DIFF
--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -64,6 +64,30 @@ impl<'a> Parser<'a, &'a [u8], ZeroPage> for ZeroPage {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct ZeroPageIndexedWithX(pub u8);
+
+impl Cyclable for ZeroPageIndexedWithX {}
+impl Offset for ZeroPageIndexedWithX {}
+
+impl<'a> Parser<'a, &'a [u8], ZeroPageIndexedWithX> for ZeroPageIndexedWithX {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], ZeroPageIndexedWithX> {
+        any_byte().map(ZeroPageIndexedWithX).parse(input)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
+pub struct ZeroPageIndexedWithY(pub u8);
+
+impl Cyclable for ZeroPageIndexedWithY {}
+impl Offset for ZeroPageIndexedWithY {}
+
+impl<'a> Parser<'a, &'a [u8], ZeroPageIndexedWithY> for ZeroPageIndexedWithY {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], ZeroPageIndexedWithY> {
+        any_byte().map(ZeroPageIndexedWithY).parse(input)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Relative(i8);
 
@@ -89,12 +113,6 @@ pub struct AbsoluteIndexedWithX(u16);
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct AbsoluteIndexedWithY(u16);
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ZeroPageIndexedWithX(u8);
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct ZeroPageIndexedWithY(u8);
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct IndexedIndirect(u8);

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -14,6 +14,7 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
         parcel::one_of(vec![
             parcel::parsers::byte::expect_byte(0xa9),
             parcel::parsers::byte::expect_byte(0xa5),
+            parcel::parsers::byte::expect_byte(0xb5),
             parcel::parsers::byte::expect_byte(0xad),
         ])
         .map(|_| LDA)

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -29,6 +29,12 @@ fn should_parse_zeropage_address_mode_lda_instruction() {
 }
 
 #[test]
+fn should_parse_zeropage_with_x_index_address_mode_lda_instruction() {
+    let bytecode = [0xb5, 0x12, 0x34];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_absolute_address_mode_sta_instruction() {
     let bytecode = [0x8d, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -56,6 +56,17 @@ fn should_cycle_on_lda_zeropage_operation() {
 }
 
 #[test]
+fn should_cycle_on_lda_zeropage_indexed_with_x_operation() {
+    let mut cpu = generate_test_cpu_with_instructions(vec![0xb5, 0x00])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x05));
+    cpu.address_map.write(0x05, 0xff).unwrap();
+
+    let state = cpu.run(4).unwrap();
+    assert_eq!(0x6002, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+}
+
+#[test]
 fn should_cycle_on_lda_absolute_operation() {
     let (ram_start, ram_end) = (0x0200, 0x5fff);
     let cpu = generate_test_cpu_with_instructions(vec![0xad, 0x00, 0x02])


### PR DESCRIPTION
# Introduction
This PR implements the zeropage indexed with X and zeropage indexed with Y address modes to facilitate the implementation of the LDA Zeropage Indexed With X instruction.

# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
