### PR TITLE
Implement CMP Immediate address mode instruction for mos6502

### DIFF
--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -2,13 +2,14 @@
 //! include write operations to memory or registers and are the basic building
 //! blocks for an instruction implementation
 
-use crate::cpu::mos6502::register::{ByteRegisters, WordRegisters};
+use crate::cpu::mos6502::register::{ByteRegisters, ProgramStatusFlags, WordRegisters};
 
 /// An Enumerable type to store each microcode operation possible on the
 /// 6502 emulator.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Microcode {
     WriteMemory(WriteMemory),
+    SetProgramStatusFlagState(SetProgramStatusFlagState),
     Write8bitRegister(Write8bitRegister),
     Inc8bitRegister(Inc8bitRegister),
     Dec8bitRegister(Dec8bitRegister),
@@ -28,6 +29,20 @@ pub struct WriteMemory {
 impl WriteMemory {
     pub fn new(address: u16, value: u8) -> Self {
         Self { address, value }
+    }
+}
+
+/// Represents a write of the value to the memory location specified by the
+/// address field.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SetProgramStatusFlagState {
+    pub flag: ProgramStatusFlags,
+    pub value: bool,
+}
+
+impl SetProgramStatusFlagState {
+    pub fn new(flag: ProgramStatusFlags, value: bool) -> Self {
+        Self { flag, value }
     }
 }
 

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -98,6 +98,16 @@ pub struct EOR;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CMP;
 
+impl Offset for CMP {}
+
+impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], CMP> {
+        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0xc9)])
+            .map(|_| CMP)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CPX;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -17,6 +17,7 @@ pub mod mnemonic;
 mod tests;
 
 /// Represents a response that will yield a result that might or might not set a carry bit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Carryable<T> {
     Set(T),
     Unset(T),
@@ -267,16 +268,13 @@ impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::CMP, address_mode::Immediate
 }
 
 impl Generate<MOS6502, MOps> for Instruction<mnemonic::CMP, address_mode::Immediate> {
-    fn generate(self, _: &MOS6502) -> MOps {
-        let address_mode::Immediate(value) = self.address_mode;
-        MOps::new(
-            self.offset(),
-            self.cycles(),
-            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-                ByteRegisters::ACC,
-                value,
-            ))],
-        )
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let address_mode::Immediate(am_value) = self.address_mode;
+        let rhs = Carryable::new(am_value);
+        let lhs = Carryable::new(cpu.acc.read());
+        let _diff = lhs - rhs;
+
+        MOps::new(self.offset(), self.cycles(), vec![])
     }
 }
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -7,6 +7,30 @@ use crate::cpu::mos6502::{
 };
 use crate::cpu::register::Register;
 
+// CMP
+
+#[test]
+fn should_generate_immediate_address_mode_cmp_machine_code() {
+    let cpu = MOS6502::default();
+    let op: Operation = Instruction::new(mnemonic::CMP, address_mode::Immediate::default()).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(MOps::new(2, 2, vec![]), mc);
+
+    // validate mops -> vector looks correct
+    assert_eq!(
+        vec![
+            vec![],
+            vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
+                WordRegisters::PC,
+                2
+            ))]
+        ],
+        Into::<Vec<Vec<Microcode>>>::into(mc)
+    )
+}
+
 // NOP
 
 #[test]

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -27,6 +27,18 @@ pub enum ByteRegisters {
     SP,
 }
 
+/// Represets each flag represented in the ProgramStatus Register.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ProgramStatusFlags {
+    Negative,
+    Overflow,
+    Break,
+    Decimal,
+    Interrupt,
+    Zero,
+    Carry,
+}
+
 /// Represets each type of general purpose register available in the mos6502.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GPRegister {

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -164,17 +164,17 @@ impl Register<u8, u8> for ProcessorStatus {
     }
 }
 
-impl Into<u8> for ProcessorStatus {
-    fn into(self) -> u8 {
+impl From<ProcessorStatus> for u8 {
+    fn from(src: ProcessorStatus) -> u8 {
         let mut ps: u8 = 0;
-        ps |= (self.negative as u8) << 7;
-        ps |= (self.overflow as u8) << 6;
-        ps |= (self.unused as u8) << 5;
-        ps |= (self.brk as u8) << 4;
-        ps |= (self.decimal as u8) << 3;
-        ps |= (self.interrupt_disable as u8) << 2;
-        ps |= (self.zero as u8) << 1;
-        ps |= self.carry as u8;
+        ps |= (src.negative as u8) << 7;
+        ps |= (src.overflow as u8) << 6;
+        ps |= (src.unused as u8) << 5;
+        ps |= (src.brk as u8) << 4;
+        ps |= (src.decimal as u8) << 3;
+        ps |= (src.interrupt_disable as u8) << 2;
+        ps |= (src.zero as u8) << 1;
+        ps |= src.carry as u8;
         ps
     }
 }


### PR DESCRIPTION
# Introduction
This PR includes an implementation of the CMP Immediate Address mode instruction for the MOS6502 cpu.

# Linked Issues
#83 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
