### PR TITLE
LDA instructions should set flags based on ACC value

### DIFF
--- a/src/cpu/mod.rs
+++ b/src/cpu/mod.rs
@@ -64,5 +64,6 @@ impl<T> From<StepState<T>> for (usize, T) {
     }
 }
 
+#[macro_use]
 pub mod mos6502;
 pub mod register;

--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -133,3 +133,12 @@ impl Dec16bitRegister {
         Self { register, value }
     }
 }
+
+#[allow(unused_macros)]
+macro_rules! gen_flag_set_microcode {
+    ($flag:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::SetProgramStatusFlagState(
+            $crate::cpu::mos6502::microcode::SetProgramStatusFlagState::new($flag, $value),
+        )
+    };
+}

--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -10,6 +10,9 @@ use crate::{
     cpu::{register::Register, StepState, CPU},
 };
 
+#[macro_use]
+pub mod microcode;
+
 #[cfg(test)]
 mod tests;
 
@@ -21,8 +24,6 @@ use register::{
 
 pub mod operations;
 use operations::Operation;
-
-pub mod microcode;
 
 pub trait Generate<T, U> {
     fn generate(self, cpu: &T) -> U;

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -90,10 +90,11 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
         MOps::new(
             2,
             2,
-            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-                ByteRegisters::ACC,
-                0xff
-            ))]
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff))
+            ]
         ),
         mc
     );
@@ -103,6 +104,8 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
         vec![
             vec![],
             vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff)),
                 Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
             ]
@@ -122,10 +125,14 @@ fn should_generate_zeropage_address_mode_lda_machine_code() {
         MOps::new(
             2,
             3,
-            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-                ByteRegisters::ACC,
-                0x00 // memory defaults to null
-            ))]
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::Write8bitRegister(Write8bitRegister::new(
+                    ByteRegisters::ACC,
+                    0x00 // memory defaults to null
+                ))
+            ]
         ),
         mc
     );
@@ -136,6 +143,8 @@ fn should_generate_zeropage_address_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
                 Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
             ]
@@ -158,10 +167,14 @@ fn should_generate_zeropage_indexed_with_x_address_mode_lda_machine_code() {
         MOps::new(
             2,
             4,
-            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-                ByteRegisters::ACC,
-                0xff // value at 0x05 in memory should be 0xff
-            ))]
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::Write8bitRegister(Write8bitRegister::new(
+                    ByteRegisters::ACC,
+                    0xff // value at 0x05 in memory should be 0xff
+                ))
+            ]
         ),
         mc
     );
@@ -173,6 +186,8 @@ fn should_generate_zeropage_indexed_with_x_address_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff)),
                 Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
             ]
@@ -192,10 +207,11 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
         MOps::new(
             3,
             4,
-            vec![Microcode::Write8bitRegister(Write8bitRegister::new(
-                ByteRegisters::ACC,
-                0x00
-            ))]
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00))
+            ]
         ),
         mc
     );
@@ -207,6 +223,8 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
             vec![],
             vec![],
             vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
                 Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
             ]

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -16,18 +16,9 @@ fn should_generate_immediate_address_mode_cmp_machine_code() {
     let op: Operation = Instruction::new(mnemonic::CMP, address_mode::Immediate::default()).into();
     let mc = op.generate(&cpu);
     let expected_mops = vec![
-        Microcode::SetProgramStatusFlagState(SetProgramStatusFlagState::new(
-            ProgramStatusFlags::Zero,
-            true,
-        )),
-        Microcode::SetProgramStatusFlagState(SetProgramStatusFlagState::new(
-            ProgramStatusFlags::Carry,
-            true,
-        )),
-        Microcode::SetProgramStatusFlagState(SetProgramStatusFlagState::new(
-            ProgramStatusFlags::Negative,
-            false,
-        )),
+        gen_flag_set_microcode!(ProgramStatusFlags::Carry, true),
+        gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+        gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
     ];
 
     // check Mops value is correct

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -66,6 +66,7 @@ fn should_cycle_on_lda_immediate_operation() {
     let state = cpu.run(4).unwrap();
     assert_eq!(0x6004, state.pc.read());
     assert_eq!(0x0f, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, false));
 }
 
 #[test]
@@ -75,6 +76,7 @@ fn should_cycle_on_lda_zeropage_operation() {
     let state = cpu.run(3).unwrap();
     assert_eq!(0x6002, state.pc.read());
     assert_eq!(0x00, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (false, true));
 }
 
 #[test]
@@ -86,6 +88,7 @@ fn should_cycle_on_lda_zeropage_indexed_with_x_operation() {
     let state = cpu.run(4).unwrap();
     assert_eq!(0x6002, state.pc.read());
     assert_eq!(0xff, state.acc.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
 }
 
 #[test]
@@ -104,6 +107,7 @@ fn should_cycle_on_lda_absolute_operation() {
     // val in mem should be null
     assert_eq!(0x00, state.acc.read());
     assert_eq!(0x00, state.address_map.read(0x0200));
+    assert_eq!((state.ps.negative, state.ps.zero), (false, true));
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,6 @@
 mod tests;
 
 pub mod address_map;
+
+#[macro_use]
 pub mod cpu;


### PR DESCRIPTION
# Introduction
This includes small fix to ensure that flags are being correctly set on LDA instructions. Additionally this introduces a macro for flag-setting microcode as this is common and contains a ton of boilerplate. 

# Linked Issues
#38 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
