### PR TITLE
Implements the TXA implied address mode instruction for the mos6502

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -149,6 +149,16 @@ pub struct TAX;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TXA;
 
+impl Offset for TXA {}
+
+impl<'a> Parser<'a, &'a [u8], TXA> for TXA {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], TXA> {
+        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0x8a)])
+            .map(|_| TXA)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TAY;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -210,6 +210,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::LDA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
+            inst_to_operation!(mnemonic::TXA, address_mode::Implied),
         ])
         .parse(input)
     }
@@ -601,6 +602,45 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::JMP, address_mode::Indire
                 WordRegisters::PC,
                 addr - self.offset() as u16,
             ))],
+        )
+    }
+}
+
+impl Cyclable for Instruction<mnemonic::TXA, address_mode::Implied> {
+    fn cycles(&self) -> usize {
+        2
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::TXA, address_mode::Implied>>
+    for Instruction<mnemonic::TXA, address_mode::Implied>
+{
+    fn parse(
+        &self,
+        input: &'a [u8],
+    ) -> ParseResult<&'a [u8], Instruction<mnemonic::TXA, address_mode::Implied>> {
+        expect_byte(0x8a)
+            .and_then(|_| address_mode::Implied)
+            .map(|am| Instruction::new(mnemonic::TXA, am))
+            .parse(input)
+    }
+}
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::TXA, address_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.acc.read());
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::Write8bitRegister(Write8bitRegister::new(
+                    ByteRegisters::X,
+                    value.unwrap(),
+                )),
+            ],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -332,3 +332,25 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
 }
+
+#[test]
+fn should_generate_implied_address_mode_txa_machine_code() {
+    let cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    let op: Operation = Instruction::new(mnemonic::TXA, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::X, 0xff))
+            ]
+        ),
+        mc
+    );
+}

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -153,3 +153,16 @@ fn should_cycle_on_jmp_indirect_operation() {
 
     assert_eq!(0xeaea, state.pc.read());
 }
+
+#[test]
+fn should_cycle_on_txa_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x8a])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.x.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}


### PR DESCRIPTION
# Introduction
This PR implements the TXA instruction for the mos6502 cpu.
# Linked Issues
#71 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
