### PR TITLE
Fix TAX and implement TXA

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -146,6 +146,16 @@ pub struct BVS;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TAX;
 
+impl Offset for TAX {}
+
+impl<'a> Parser<'a, &'a [u8], TAX> for TAX {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], TAX> {
+        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0xaa)])
+            .map(|_| TAX)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TXA;
 

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -334,10 +334,10 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
 }
 
 #[test]
-fn should_generate_implied_address_mode_txa_machine_code() {
+fn should_generate_implied_address_mode_tax_machine_code() {
     let cpu =
         MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
-    let op: Operation = Instruction::new(mnemonic::TXA, address_mode::Implied).into();
+    let op: Operation = Instruction::new(mnemonic::TAX, address_mode::Implied).into();
     let mc = op.generate(&cpu);
 
     // check Mops value is correct
@@ -349,6 +349,27 @@ fn should_generate_implied_address_mode_txa_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::X, 0xff))
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_implied_address_mode_txa_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0xff));
+    let op: Operation = Instruction::new(mnemonic::TXA, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff))
             ]
         ),
         mc

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -45,3 +45,15 @@ fn should_parse_absolute_address_mode_jmp_instruction() {
     let bytecode = [0x4c, 0x34, 0x12];
     gen_op_parse_assertion!(&bytecode);
 }
+
+#[test]
+fn should_parse_implied_address_mode_tax_instruction() {
+    let bytecode = [0xaa, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_implied_address_mode_txa_instruction() {
+    let bytecode = [0x8a, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -155,10 +155,23 @@ fn should_cycle_on_jmp_indirect_operation() {
 }
 
 #[test]
-fn should_cycle_on_txa_implied_operation() {
-    let cpu = generate_test_cpu_with_instructions(vec![0x8a])
+fn should_cycle_on_tax_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xaa])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
         .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.x.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
+fn should_cycle_on_txa_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x8a])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x00))
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0xff));
 
     let state = cpu.run(2).unwrap();
     assert_eq!(0x6001, state.pc.read());


### PR DESCRIPTION
# Introduction
This PR fixes the TXA command which was previously an implementation of TAX and then implements TXA correctly for the mos6502.
# Linked Issues
resolves #71 
#78 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
