### PR TITLE
Implement TAY Implied address mode instruction

### DIFF
--- a/src/cpu/mos6502/mod.rs
+++ b/src/cpu/mos6502/mod.rs
@@ -290,7 +290,7 @@ impl Execute<MOS6502> for microcode::Write8bitRegister {
                 cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(value))
             }
             ByteRegisters::Y => {
-                cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(value))
+                cpu.with_gp_register(GPRegister::Y, GeneralPurpose::with_value(value))
             }
             ByteRegisters::SP => cpu.with_sp_register(StackPointer::with_value(value)),
             ByteRegisters::PS => cpu.with_ps_register(ProcessorStatus::with_value(value)),
@@ -314,7 +314,7 @@ impl Execute<MOS6502> for microcode::Inc8bitRegister {
             }
             ByteRegisters::Y => {
                 let old_val = cpu.y.read();
-                cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(old_val + value))
+                cpu.with_gp_register(GPRegister::Y, GeneralPurpose::with_value(old_val + value))
             }
             ByteRegisters::SP => {
                 let old_val = cpu.sp.read();
@@ -343,7 +343,7 @@ impl Execute<MOS6502> for microcode::Dec8bitRegister {
             }
             ByteRegisters::Y => {
                 let old_val = cpu.y.read();
-                cpu.with_gp_register(GPRegister::X, GeneralPurpose::with_value(old_val - value))
+                cpu.with_gp_register(GPRegister::Y, GeneralPurpose::with_value(old_val - value))
             }
             ByteRegisters::SP => {
                 let old_val = cpu.sp.read();

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -172,6 +172,16 @@ impl<'a> Parser<'a, &'a [u8], TXA> for TXA {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TAY;
 
+impl Offset for TAY {}
+
+impl<'a> Parser<'a, &'a [u8], TAY> for TAY {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], TAY> {
+        parcel::one_of(vec![parcel::parsers::byte::expect_byte(0xa8)])
+            .map(|_| TAY)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TYA;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -211,6 +211,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::NOP, address_mode::Implied),
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::TAX, address_mode::Implied),
+            inst_to_operation!(mnemonic::TAY, address_mode::Implied),
             inst_to_operation!(mnemonic::TXA, address_mode::Implied),
         ])
         .parse(input)
@@ -639,6 +640,45 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::TAX, address_mode::Implie
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 Microcode::Write8bitRegister(Write8bitRegister::new(
                     ByteRegisters::X,
+                    value.unwrap(),
+                )),
+            ],
+        )
+    }
+}
+
+impl Cyclable for Instruction<mnemonic::TAY, address_mode::Implied> {
+    fn cycles(&self) -> usize {
+        2
+    }
+}
+
+impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::TAY, address_mode::Implied>>
+    for Instruction<mnemonic::TAY, address_mode::Implied>
+{
+    fn parse(
+        &self,
+        input: &'a [u8],
+    ) -> ParseResult<&'a [u8], Instruction<mnemonic::TAY, address_mode::Implied>> {
+        expect_byte(0xa8)
+            .and_then(|_| address_mode::Implied)
+            .map(|am| Instruction::new(mnemonic::TAY, am))
+            .parse(input)
+    }
+}
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::TAY, address_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.acc.read());
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                Microcode::Write8bitRegister(Write8bitRegister::new(
+                    ByteRegisters::Y,
                     value.unwrap(),
                 )),
             ],

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -356,6 +356,28 @@ fn should_generate_implied_address_mode_tax_machine_code() {
 }
 
 #[test]
+fn should_generate_implied_address_mode_tay_machine_code() {
+    let cpu =
+        MOS6502::default().with_gp_register(GPRegister::ACC, GeneralPurpose::with_value(0xff));
+    let op: Operation = Instruction::new(mnemonic::TAY, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::Y, 0xff))
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
 fn should_generate_implied_address_mode_txa_machine_code() {
     let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0xff));
     let op: Operation = Instruction::new(mnemonic::TXA, address_mode::Implied).into();

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -53,6 +53,12 @@ fn should_parse_implied_address_mode_tax_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_tay_instruction() {
+    let bytecode = [0xa8, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_txa_instruction() {
     let bytecode = [0x8a, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -168,6 +168,19 @@ fn should_cycle_on_tax_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_tay_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xa8])
+        .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0xff))
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(0x00));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xff, state.acc.read());
+    assert_eq!(0xff, state.y.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
 fn should_cycle_on_txa_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x8a])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x00))


### PR DESCRIPTION
# Introduction
This PR fixes a bug where Y microcode would right to the X register and also implements they TAY Implied addressmode instruction for the mos6502 processor.

# Linked Issues
#77
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
