### PR TITLE
Add helper macros for parser and microcode gen.

### DIFF
--- a/src/cpu/mos6502/microcode.rs
+++ b/src/cpu/mos6502/microcode.rs
@@ -135,10 +135,73 @@ impl Dec16bitRegister {
 }
 
 #[allow(unused_macros)]
+macro_rules! gen_write_memory_microcode {
+    ($addr:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::WriteMemory(
+            $crate::cpu::mos6502::microcode::WriteMemory::new($addr, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
 macro_rules! gen_flag_set_microcode {
     ($flag:expr, $value:expr) => {
         $crate::cpu::mos6502::microcode::Microcode::SetProgramStatusFlagState(
             $crate::cpu::mos6502::microcode::SetProgramStatusFlagState::new($flag, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! gen_write_8bit_register_microcode {
+    ($reg:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::Write8bitRegister(
+            $crate::cpu::mos6502::microcode::Write8bitRegister::new($reg, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! gen_inc_8bit_register_microcode {
+    ($reg:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::Inc8bitRegister(
+            $crate::cpu::mos6502::microcode::Inc8bitRegister::new($reg, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! gen_dec_8bit_register_microcode {
+    ($reg:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::Dec8bitRegister(
+            $crate::cpu::mos6502::microcode::Dec8bitRegister::new($reg, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! gen_write_16bit_register_microcode {
+    ($reg:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::Write16bitRegister(
+            $crate::cpu::mos6502::microcode::Write16bitRegister::new($reg, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! gen_inc_16bit_register_microcode {
+    ($reg:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::Inc16bitRegister(
+            $crate::cpu::mos6502::microcode::Inc16bitRegister::new($reg, $value),
+        )
+    };
+}
+
+#[allow(unused_macros)]
+macro_rules! gen_dec_16bit_register_microcode {
+    ($reg:expr, $value:expr) => {
+        $crate::cpu::mos6502::microcode::Microcode::Dec16bitRegister(
+            $crate::cpu::mos6502::microcode::Dec16bitRegister::new($reg, $value),
         )
     };
 }

--- a/src/cpu/mos6502/operations/address_mode.rs
+++ b/src/cpu/mos6502/operations/address_mode.rs
@@ -8,7 +8,7 @@ pub struct Accumulator;
 /// Implied address address mode. This is signified by no address mode
 /// arguments. An example instruction with an implied address mode would be.
 /// `nop`
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Implied;
 
 impl Offset for Implied {

--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -3,7 +3,7 @@ use crate::cpu::{Cyclable, Offset};
 use parcel::{ParseResult, Parser};
 
 // Load-Store
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDA;
 
 impl Cyclable for LDA {}
@@ -22,13 +22,13 @@ impl<'a> Parser<'a, &'a [u8], LDA> for LDA {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDX;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LDY;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct STA;
 
 impl Offset for STA {}
@@ -41,61 +41,61 @@ impl<'a> Parser<'a, &'a [u8], STA> for STA {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct STX;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct STY;
 
 // Arithmetic
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ADC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SBC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INX;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INY;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEX;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEY;
 
 // Shift and Rotate
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ASL;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct LSR;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROL;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ROR;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct AND;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct ORA;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct EOR;
 
 // Compare and Test Bit
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CMP;
 
 impl Offset for CMP {}
@@ -108,42 +108,42 @@ impl<'a> Parser<'a, &'a [u8], CMP> for CMP {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CPX;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CPY;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BIT;
 
 // Branch
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BCC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BCS;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BNE;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BEQ;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BPL;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BMI;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BVC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BVS;
 
 // Transfer
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TAX;
 
 impl Offset for TAX {}
@@ -156,7 +156,7 @@ impl<'a> Parser<'a, &'a [u8], TAX> for TAX {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TXA;
 
 impl Offset for TXA {}
@@ -169,7 +169,7 @@ impl<'a> Parser<'a, &'a [u8], TXA> for TXA {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TAY;
 
 impl Offset for TAY {}
@@ -182,7 +182,7 @@ impl<'a> Parser<'a, &'a [u8], TAY> for TAY {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TYA;
 
 impl Offset for TYA {}
@@ -195,30 +195,30 @@ impl<'a> Parser<'a, &'a [u8], TYA> for TYA {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TSX;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TXS;
 
 // Stack Operations
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PHA;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PLA;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PHP;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PLP;
 
 // Subroutines and Jump
 
 /// Represents a `jmp` instruction, only implemented for the absolute address
 /// and indirect modes and functions as jump to a location in memory.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct JMP;
 
 impl Offset for JMP {}
@@ -234,44 +234,44 @@ impl<'a> Parser<'a, &'a [u8], JMP> for JMP {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct JSR;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct RTS;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct RTI;
 
 // Set and Clear
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SEC;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLD;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SED;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLI;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct SEI;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct CLV;
 
 // Misc
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct BRK;
 
 /// Represents a `nop` instruction, only implemented for the implied address
 /// mode and functions as a "No Instruction".
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct NOP;
 
 impl Offset for NOP {}


### PR DESCRIPTION
# Introduction
This PR implements a few helper macros for emitting microcode. These are essentially 1-1 with the former now becoming the latter.

```rust
crate::cpu::mos6502::microcode::Microcode::Inc16bitRegister(
    crate::cpu::mos6502::microcode::Inc16bitRegister::new(WordRegisters::PC, 0x7ffc),
)
```

```rust
gen_inc_16bit_register_microcode!(WordRegisters::PC, 0x7ffc)
```

Additionally this adds a helper macro for generating parser and cycle implementations for each instruction. With the former now becoming the latter.

```rust
impl Cyclable for Instruction<mnemonic::JMP, address_mode::Absolute> {
gen_instruction_cycles_and_parser!(mnemonic::STA, address_mode::Absolute, 0x8d, 4);
    fn cycles(&self) -> usize {
        3
    }
}


impl<'a> Parser<'a, &'a [u8], Instruction<mnemonic::JMP, address_mode::Absolute>>
impl Generate<MOS6502, MOps> for Instruction<mnemonic::STA, address_mode::Absolute> {
    for Instruction<mnemonic::JMP, address_mode::Absolute>
{
    fn parse(
        &self,
        input: &'a [u8],
    ) -> ParseResult<&'a [u8], Instruction<mnemonic::JMP, address_mode::Absolute>> {
        expect_byte(0x4c)
            .and_then(|_| address_mode::Absolute::default())
            .map(|am| Instruction::new(mnemonic::JMP, am))
            .parse(input)
    }
}
```

```rust
gen_instruction_cycles_and_parser!(mnemonic::JMP, address_mode::Absolute, 0x4c, 3);
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
