### PR TITLE
Implement INY implied instructions

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -72,6 +72,16 @@ impl<'a> Parser<'a, &'a [u8], INX> for INX {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct INY;
 
+impl Offset for INY {}
+
+impl<'a> Parser<'a, &'a [u8], INY> for INY {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], INY> {
+        parcel::parsers::byte::expect_byte(0xc8)
+            .map(|_| INY)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct DEC;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -206,6 +206,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::CLC, address_mode::Implied),
             inst_to_operation!(mnemonic::CMP, address_mode::Immediate::default()),
             inst_to_operation!(mnemonic::INX, address_mode::Implied),
+            inst_to_operation!(mnemonic::INY, address_mode::Implied),
             inst_to_operation!(mnemonic::JMP, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::JMP, address_mode::Indirect::default()),
             inst_to_operation!(mnemonic::LDA, address_mode::Immediate::default()),
@@ -350,6 +351,26 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::INX, address_mode::Implie
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
+            ],
+        )
+    }
+}
+
+// INY
+
+gen_instruction_cycles_and_parser!(mnemonic::INY, address_mode::Implied, 0xc8, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::INY, address_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.y.read()) + Operand::new(1);
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -68,7 +68,7 @@ fn should_generate_immediate_address_mode_cmp_machine_code() {
     )
 }
 
-// CLC
+// INX
 
 #[test]
 fn should_generate_implied_address_mode_inx_machine_code() {
@@ -85,6 +85,29 @@ fn should_generate_implied_address_mode_inx_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
                 gen_write_8bit_register_microcode!(ByteRegisters::X, 0x13)
+            ]
+        ),
+        mc
+    );
+}
+
+// INY
+
+#[test]
+fn should_generate_implied_address_mode_iny_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::Y, GeneralPurpose::with_value(0x12));
+    let op: Operation = Instruction::new(mnemonic::INY, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0x13)
             ]
         ),
         mc

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -18,7 +18,13 @@ fn should_parse_implied_address_mode_clc_instruction() {
 
 #[test]
 fn should_parse_implied_address_mode_inx_instruction() {
-    let bytecode = [0xE8, 0x00, 0x00];
+    let bytecode = [0xe8, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
+fn should_parse_implied_address_mode_iny_instruction() {
+    let bytecode = [0xc8, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);
 }
 

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -76,6 +76,19 @@ fn should_cycle_on_inx_implied_operation() {
 
     let state = cpu.run(2).unwrap();
     assert_eq!(0x6001, state.pc.read());
+    assert_eq!(128, state.x.read());
+    assert_eq!((true, false), (state.ps.negative, state.ps.zero));
+}
+
+#[test]
+fn should_cycle_on_iny_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xc8])
+        .with_gp_register(GPRegister::Y, register::GeneralPurpose::with_value(127));
+    assert_eq!(false, cpu.ps.negative);
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(128, state.y.read());
     assert_eq!((true, false), (state.ps.negative, state.ps.zero));
 }
 


### PR DESCRIPTION
# Introduction
Implement the INY implied address mode instruction for the mos6502 processor
# Linked Issues
#85 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
