### PR TITLE
Implement TSX implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -217,6 +217,16 @@ impl<'a> Parser<'a, &'a [u8], TYA> for TYA {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TSX;
 
+impl Offset for TSX {}
+
+impl<'a> Parser<'a, &'a [u8], TSX> for TSX {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], TSX> {
+        parcel::parsers::byte::expect_byte(0xba)
+            .map(|_| TSX)
+            .parse(input)
+    }
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TXS;
 

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -217,6 +217,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::STA, address_mode::Absolute::default()),
             inst_to_operation!(mnemonic::TAX, address_mode::Implied),
             inst_to_operation!(mnemonic::TAY, address_mode::Implied),
+            inst_to_operation!(mnemonic::TSX, address_mode::Implied),
             inst_to_operation!(mnemonic::TXA, address_mode::Implied),
             inst_to_operation!(mnemonic::TYA, address_mode::Implied),
         ])
@@ -553,6 +554,26 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::TAY, address_mode::Implie
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::Y, value.unwrap()),
+            ],
+        )
+    }
+}
+
+// TSX
+
+gen_instruction_cycles_and_parser!(mnemonic::TSX, address_mode::Implied, 0xba, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::TSX, address_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.sp.read());
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, value.negative),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
+                gen_write_8bit_register_microcode!(ByteRegisters::X, value.unwrap()),
             ],
         )
     }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -4,7 +4,7 @@ use crate::cpu::mos6502::{
     operations::{address_mode, mnemonic, Instruction, MOps, Operation},
     register::{
         ByteRegisters, GPRegister, GeneralPurpose, ProcessorStatus, ProgramStatusFlags,
-        WordRegisters,
+        StackPointer, WordRegisters,
     },
     Generate, MOS6502,
 };
@@ -441,6 +441,27 @@ fn should_generate_implied_address_mode_tay_machine_code() {
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
                 Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::Y, 0xff))
+            ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_implied_address_mode_tsx_machine_code() {
+    let cpu = MOS6502::default().with_sp_register(StackPointer::default());
+    let op: Operation = Instruction::new(mnemonic::TSX, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![
+                gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
+                gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
+                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::X, 0xff))
             ]
         ),
         mc

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -77,6 +77,12 @@ fn should_parse_implied_address_mode_tay_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_tsx_instruction() {
+    let bytecode = [0xba, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_txa_instruction() {
     let bytecode = [0x8a, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/register.rs
+++ b/src/cpu/mos6502/register.rs
@@ -88,17 +88,9 @@ pub struct StackPointer {
     inner: u8,
 }
 
-impl StackPointer {
-    /// instantiates a new stack pointer register with a value.
-    pub fn with_value(inner: u8) -> Self {
-        Self::default().write(inner)
-    }
-}
-
-impl Register<u16, u8> for StackPointer {
-    fn read(&self) -> u16 {
-        let bp: u16 = 0x0100;
-        bp + self.inner as u16
+impl Register<u8, u8> for StackPointer {
+    fn read(&self) -> u8 {
+        self.inner
     }
 
     fn write(self, value: u8) -> Self {

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -214,6 +214,19 @@ fn should_cycle_on_tay_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_tsx_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0xba])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00))
+        .with_sp_register(register::StackPointer::with_value(0xff));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0xff, state.sp.read());
+    assert_eq!(0xff, state.x.read());
+    assert_eq!((state.ps.negative, state.ps.zero), (true, false));
+}
+
+#[test]
 fn should_cycle_on_txa_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x8a])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x00))


### PR DESCRIPTION
# Introduction
This PR implements the TSX Implied instruction for the MOS6502 processor.

# Linked Issues
#81 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
