### PR TITLE
Implement TXS Implied instruction

### DIFF
--- a/src/cpu/mos6502/operations/mnemonic.rs
+++ b/src/cpu/mos6502/operations/mnemonic.rs
@@ -230,6 +230,16 @@ impl<'a> Parser<'a, &'a [u8], TSX> for TSX {
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct TXS;
 
+impl Offset for TXS {}
+
+impl<'a> Parser<'a, &'a [u8], TXS> for TXS {
+    fn parse(&self, input: &'a [u8]) -> ParseResult<&'a [u8], TXS> {
+        parcel::parsers::byte::expect_byte(0x9a)
+            .map(|_| TXS)
+            .parse(input)
+    }
+}
+
 // Stack Operations
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct PHA;

--- a/src/cpu/mos6502/operations/mod.rs
+++ b/src/cpu/mos6502/operations/mod.rs
@@ -219,6 +219,7 @@ impl<'a> Parser<'a, &'a [u8], Operation> for OperationParser {
             inst_to_operation!(mnemonic::TAY, address_mode::Implied),
             inst_to_operation!(mnemonic::TSX, address_mode::Implied),
             inst_to_operation!(mnemonic::TXA, address_mode::Implied),
+            inst_to_operation!(mnemonic::TXS, address_mode::Implied),
             inst_to_operation!(mnemonic::TYA, address_mode::Implied),
         ])
         .parse(input)
@@ -595,6 +596,25 @@ impl Generate<MOS6502, MOps> for Instruction<mnemonic::TXA, address_mode::Implie
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, value.zero),
                 gen_write_8bit_register_microcode!(ByteRegisters::ACC, value.unwrap()),
             ],
+        )
+    }
+}
+
+// TSX
+
+gen_instruction_cycles_and_parser!(mnemonic::TXS, address_mode::Implied, 0x9a, 2);
+
+impl Generate<MOS6502, MOps> for Instruction<mnemonic::TXS, address_mode::Implied> {
+    fn generate(self, cpu: &MOS6502) -> MOps {
+        let value = Operand::new(cpu.x.read());
+
+        MOps::new(
+            self.offset(),
+            self.cycles(),
+            vec![gen_write_8bit_register_microcode!(
+                ByteRegisters::SP,
+                value.unwrap()
+            )],
         )
     }
 }

--- a/src/cpu/mos6502/operations/tests/code_generation.rs
+++ b/src/cpu/mos6502/operations/tests/code_generation.rs
@@ -55,13 +55,7 @@ fn should_generate_immediate_address_mode_cmp_machine_code() {
             expected_mops
                 .clone()
                 .into_iter()
-                .chain(
-                    vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                        WordRegisters::PC,
-                        2
-                    ))]
-                    .into_iter()
-                )
+                .chain(vec![gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)].into_iter())
                 .collect()
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -129,10 +123,7 @@ fn should_generate_implied_address_mode_nop_machine_code() {
     assert_eq!(
         vec![
             vec![],
-            vec![Microcode::Inc16bitRegister(Inc16bitRegister::new(
-                WordRegisters::PC,
-                1
-            ))]
+            vec![gen_inc_16bit_register_microcode!(WordRegisters::PC, 1)]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
     )
@@ -154,7 +145,7 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xff)
             ]
         ),
         mc
@@ -167,8 +158,8 @@ fn should_generate_immediate_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff)),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xff),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -189,10 +180,10 @@ fn should_generate_zeropage_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
-                Microcode::Write8bitRegister(Write8bitRegister::new(
+                gen_write_8bit_register_microcode!(
                     ByteRegisters::ACC,
                     0x00 // memory defaults to null
-                ))
+                )
             ]
         ),
         mc
@@ -206,8 +197,8 @@ fn should_generate_zeropage_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -231,10 +222,10 @@ fn should_generate_zeropage_indexed_with_x_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(
+                gen_write_8bit_register_microcode!(
                     ByteRegisters::ACC,
                     0xff // value at 0x05 in memory should be 0xff
-                ))
+                )
             ]
         ),
         mc
@@ -249,8 +240,8 @@ fn should_generate_zeropage_indexed_with_x_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff)),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 2))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xff),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 2)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -271,7 +262,7 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00)
             ]
         ),
         mc
@@ -286,8 +277,8 @@ fn should_generate_absolute_address_mode_lda_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, false),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, true),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0x00)),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0x00),
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -320,7 +311,7 @@ fn should_generate_absolute_address_mode_sta_machine_code() {
             vec![],
             vec![
                 Microcode::WriteMemory(WriteMemory::new(0x0100, 0x00)),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -354,7 +345,7 @@ fn should_generate_absolute_address_mode_jmp_machine_code() {
             vec![],
             vec![
                 Microcode::Write16bitRegister(Write16bitRegister::new(WordRegisters::PC, addr - 3)),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -396,7 +387,7 @@ fn should_generate_indirect_address_mode_jmp_machine_code() {
                     WordRegisters::PC,
                     indirect_addr - 3
                 )),
-                Microcode::Inc16bitRegister(Inc16bitRegister::new(WordRegisters::PC, 3))
+                gen_inc_16bit_register_microcode!(WordRegisters::PC, 3)
             ]
         ],
         Into::<Vec<Vec<Microcode>>>::into(mc)
@@ -418,7 +409,7 @@ fn should_generate_implied_address_mode_tax_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::X, 0xff))
+                gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
             ]
         ),
         mc
@@ -440,7 +431,7 @@ fn should_generate_implied_address_mode_tay_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::Y, 0xff))
+                gen_write_8bit_register_microcode!(ByteRegisters::Y, 0xff)
             ]
         ),
         mc
@@ -461,7 +452,7 @@ fn should_generate_implied_address_mode_tsx_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::X, 0xff))
+                gen_write_8bit_register_microcode!(ByteRegisters::X, 0xff)
             ]
         ),
         mc
@@ -482,8 +473,25 @@ fn should_generate_implied_address_mode_txa_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xff)
             ]
+        ),
+        mc
+    );
+}
+
+#[test]
+fn should_generate_implied_address_mode_txs_machine_code() {
+    let cpu = MOS6502::default().with_gp_register(GPRegister::X, GeneralPurpose::with_value(0x00));
+    let op: Operation = Instruction::new(mnemonic::TXS, address_mode::Implied).into();
+    let mc = op.generate(&cpu);
+
+    // check Mops value is correct
+    assert_eq!(
+        MOps::new(
+            1,
+            2,
+            vec![gen_write_8bit_register_microcode!(ByteRegisters::SP, 0x00)]
         ),
         mc
     );
@@ -503,7 +511,7 @@ fn should_generate_implied_address_mode_tya_machine_code() {
             vec![
                 gen_flag_set_microcode!(ProgramStatusFlags::Negative, true),
                 gen_flag_set_microcode!(ProgramStatusFlags::Zero, false),
-                Microcode::Write8bitRegister(Write8bitRegister::new(ByteRegisters::ACC, 0xff))
+                gen_write_8bit_register_microcode!(ByteRegisters::ACC, 0xff)
             ]
         ),
         mc

--- a/src/cpu/mos6502/operations/tests/mod.rs
+++ b/src/cpu/mos6502/operations/tests/mod.rs
@@ -89,6 +89,12 @@ fn should_parse_implied_address_mode_txa_instruction() {
 }
 
 #[test]
+fn should_parse_implied_address_mode_txs_instruction() {
+    let bytecode = [0x9a, 0x00, 0x00];
+    gen_op_parse_assertion!(&bytecode);
+}
+
+#[test]
 fn should_parse_implied_address_mode_tya_instruction() {
     let bytecode = [0x98, 0x00, 0x00];
     gen_op_parse_assertion!(&bytecode);

--- a/src/cpu/mos6502/tests/mod.rs
+++ b/src/cpu/mos6502/tests/mod.rs
@@ -240,6 +240,18 @@ fn should_cycle_on_txa_implied_operation() {
 }
 
 #[test]
+fn should_cycle_on_txs_implied_operation() {
+    let cpu = generate_test_cpu_with_instructions(vec![0x9a])
+        .with_gp_register(GPRegister::X, register::GeneralPurpose::with_value(0x00))
+        .with_sp_register(register::StackPointer::with_value(0xff));
+
+    let state = cpu.run(2).unwrap();
+    assert_eq!(0x6001, state.pc.read());
+    assert_eq!(0x00, state.sp.read());
+    assert_eq!(0x00, state.x.read());
+}
+
+#[test]
 fn should_cycle_on_tya_implied_operation() {
     let cpu = generate_test_cpu_with_instructions(vec![0x98])
         .with_gp_register(GPRegister::ACC, register::GeneralPurpose::with_value(0x00))


### PR DESCRIPTION
# Introduction
Implements the TXS Implied address mode instruction for the mos6502 processor.
# Linked Issues
#74 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
